### PR TITLE
fix: fix attribute selectors like ^= and *=

### DIFF
--- a/test/fixtures/attribute2/light.html
+++ b/test/fixtures/attribute2/light.html
@@ -1,0 +1,15 @@
+<!--
+  Copyright (c) 2019, salesforce.com, inc.
+  All rights reserved.
+  SPDX-License-Identifier: BSD-3-Clause
+  For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+-->
+<body>
+    <div class="container">
+      <div class="component">
+          <span class="text" data-foo="Hello world">
+              Hello
+          </span>
+      </div>
+    </div>
+</body>

--- a/test/fixtures/attribute2/shadow.html
+++ b/test/fixtures/attribute2/shadow.html
@@ -1,0 +1,29 @@
+<!--
+  Copyright (c) 2019, salesforce.com, inc.
+  All rights reserved.
+  SPDX-License-Identifier: BSD-3-Clause
+  For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+-->
+<body>
+    <div class="container"></div>
+    <script>
+      class FancyComponent extends HTMLElement {
+        constructor() {
+          super()
+          const shadowRoot = this.attachShadow({mode: 'open'})
+          shadowRoot.innerHTML = `
+            <span class="text" data-foo="Hello world">
+              Hello
+            </span>`
+        }
+
+        connectedCallback() {
+          this.setAttribute('class', 'component')
+        }
+      }
+
+      customElements.define('fancy-component', FancyComponent)
+
+      document.querySelector('.container').appendChild(new FancyComponent())
+    </script>
+</body>

--- a/test/test.js
+++ b/test/test.js
@@ -14,6 +14,8 @@ import deepLight1 from './fixtures/deep1/light.html'
 import deepShadow1 from './fixtures/deep1/shadow.html'
 import attributeLight1 from './fixtures/attribute1/light.html'
 import attributeShadow1 from './fixtures/attribute1/shadow.html'
+import attributeLight2 from './fixtures/attribute2/light.html'
+import attributeShadow2 from './fixtures/attribute2/shadow.html'
 import siblingLight1 from './fixtures/sibling1/light.html'
 import siblingShadow1 from './fixtures/sibling1/shadow.html'
 import idLight1 from './fixtures/id1/light.html'
@@ -231,6 +233,57 @@ describe('basic test suite', function () {
       },
       {
         selector: '[data-foo="fake"]',
+        expected: []
+      }
+    ])
+  })
+
+  describe('attribute selectors like *= and ^=', () => {
+    const expected = [
+      {
+        tagName: 'SPAN',
+        classList: ['text']
+      }
+    ]
+    testSelectors(attributeLight2, attributeShadow2, [
+      {
+        selector: '[data-foo^="Hello"]',
+        expected
+      },
+      {
+        selector: '[data-foo*="world"]',
+        expected
+      },
+      {
+        selector: '[data-foo$="world"]',
+        expected
+      },
+      {
+        selector: '[data-foo~="world"]',
+        expected
+      },
+      {
+        selector: '[data-foo|="Hello world"]',
+        expected
+      },
+      {
+        selector: '[data-foo*="HeLLo WoRLd" i]',
+        expected
+      },
+      {
+        selector: '[data-foo*="wrrrrld"]',
+        expected: []
+      },
+      {
+        selector: '[data-foo$="Hello"]',
+        expected: []
+      },
+      {
+        selector: '[data-foo^="world"]',
+        expected: []
+      },
+      {
+        selector: '[data-foo*="HeLLo WoRLd"]',
         expected: []
       }
     ])


### PR DESCRIPTION
fixes #2

For attribute selectors, using `getAttribute()` and `hasAttribute()` is just a bit too fragile. As it turns out, there are lots of fancy [attribute selectors](https://developer.mozilla.org/en-US/docs/Web/CSS/Attribute_selectors) and I don't want to code them all myself in JavaScript.

So we can just use the same strategy we already use for pseudo-selectors and just pass the attribute selector directly into `element.matches()`.