### PR TITLE
fix: add git repo information to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,5 +52,13 @@
   },
   "files": [
     "dist"
-  ]
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/salesforce/kagekiri.git"
+  },
+  "bugs": {
+    "url": "https://github.com/salesforce/kagekiri/issues"
+  },
+  "homepage": "https://github.com/salesforce/kagekiri#readme"
 }


### PR DESCRIPTION
This info is missing on our npm page currently: https://www.npmjs.com/package/kagekiri