### PR TITLE
fix: bundle postcss-selector-parser into dist

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -824,7 +824,8 @@
     "cssesc": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
-      "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg=="
+      "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
+      "dev": true
     },
     "custom-event": {
       "version": "1.0.1",
@@ -2567,7 +2568,8 @@
     "indexes-of": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/indexes-of/-/indexes-of-1.0.1.tgz",
-      "integrity": "sha1-8w9xbI4r00bHtn0985FVZqfAVgc="
+      "integrity": "sha1-8w9xbI4r00bHtn0985FVZqfAVgc=",
+      "dev": true
     },
     "indexof": {
       "version": "0.0.1",
@@ -3960,6 +3962,7 @@
     "postcss-selector-parser": {
       "version": "github:nolanlawson/postcss-selector-parser#75e38f7a7db8d58fb033ab7d24414b55d81e5b4f",
       "from": "github:nolanlawson/postcss-selector-parser#util-deprecate",
+      "dev": true,
       "requires": {
         "cssesc": "^3.0.0",
         "indexes-of": "^1.0.1",
@@ -5242,7 +5245,8 @@
     "uniq": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/uniq/-/uniq-1.0.1.tgz",
-      "integrity": "sha1-sxxa6CVIRKOoKBVBzisEuGWnNP8="
+      "integrity": "sha1-sxxa6CVIRKOoKBVBzisEuGWnNP8=",
+      "dev": true
     },
     "universalify": {
       "version": "0.1.2",
@@ -5349,7 +5353,8 @@
     "util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+      "dev": true
     },
     "utils-merge": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -26,9 +26,7 @@
     "name": "Nolan Lawson"
   },
   "license": "BSD-3-Clause",
-  "dependencies": {
-    "postcss-selector-parser": "nolanlawson/postcss-selector-parser#util-deprecate"
-  },
+  "dependencies": {},
   "devDependencies": {
     "assert": "^2.0.0",
     "karma": "^4.1.0",
@@ -39,6 +37,7 @@
     "karma-rollup-preprocessor": "^7.0.0",
     "mocha": "^6.1.4",
     "object-assign": "^4.1.1",
+    "postcss-selector-parser": "nolanlawson/postcss-selector-parser#util-deprecate",
     "rollup": "^1.11.3",
     "rollup-plugin-buble": "^0.19.6",
     "rollup-plugin-commonjs": "^9.3.4",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -11,13 +11,13 @@ import globals from 'rollup-plugin-node-globals'
 import buble from 'rollup-plugin-buble'
 import { terser } from 'rollup-plugin-terser'
 import inject from 'rollup-plugin-inject'
-import pkg from './package.json'
 
-const deps = Object.keys(pkg.dependencies)
+// Note that postcss-selector-parser is bundled into all outputs because its deps (util.promisify)
+// cause problems depending on the consumer's bundler. We can make things simpler for consumers of
+// kagekiri by just bundling our dependencies.
 
 function config (file, format, opts = {}) {
   const plugins = opts.plugins || []
-  const external = opts.external || []
   return {
     input: './src/index.js',
     output: {
@@ -42,16 +42,15 @@ function config (file, format, opts = {}) {
         exclude: 'node_modules/object-assign/**'
       }),
       ...plugins
-    ],
-    external
+    ]
   }
 }
 
 export default [
   config('dist/kagekiri.umd.js', 'umd'),
   config('dist/kagekiri.umd.min.js', 'umd', { plugins: [terser()] }),
-  config('dist/kagekiri.cjs.js', 'cjs', { external: deps }),
-  config('dist/kagekiri.es.js', 'es', { external: deps }),
+  config('dist/kagekiri.cjs.js', 'cjs'),
+  config('dist/kagekiri.es.js', 'es'),
   config('dist/kagekiri.iife.js', 'iife'),
   config('dist/kagekiri.iife.min.js', 'iife', { plugins: [terser()] })
 ]


### PR DESCRIPTION
I've noticed that, when using `kagekiri` as a dependency, bundlers like pika-pack may fail because of weirdness around `postcss-selector-parser`'s dependency on the built-in Node module `util` referenced by `util.promisify`.

There are arcane ways to fix this in your bundler, but then we're requiring all consumers of kagekiri to know how to do this for whatever bundler they're using (Rollup, Webpack, pika-pack, etc.). It's much simpler to just bundle `postcss-selector-parser` into all our output bundles, and to treat it as a `devDependency`.