### PR TITLE
perf: add sideEffects: false

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,5 +58,6 @@
   "bugs": {
     "url": "https://github.com/salesforce/kagekiri/issues"
   },
-  "homepage": "https://github.com/salesforce/kagekiri#readme"
+  "homepage": "https://github.com/salesforce/kagekiri#readme",
+  "sideEffects": false
 }


### PR DESCRIPTION
This tells bundlers that they can safely tree-shake the ES module output: https://webpack.js.org/guides/tree-shaking/

So for instance, consumers can use `querySelectorAll` without having to import code for `querySelector`.