### PR TITLE
fix: fix String startsWith/endsWith in IE

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5026,6 +5026,18 @@
         "strip-ansi": "^4.0.0"
       }
     },
+    "string.prototype.endswith": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/string.prototype.endswith/-/string.prototype.endswith-0.2.0.tgz",
+      "integrity": "sha1-oZwg3uUamHd+mkfhDwm+OTubunU=",
+      "dev": true
+    },
+    "string.prototype.startswith": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/string.prototype.startswith/-/string.prototype.startswith-0.2.0.tgz",
+      "integrity": "sha1-2miYLjU6TprEpDtFCiBF0cRFrns=",
+      "dev": true
+    },
     "string_decoder": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,9 @@
     "rollup-plugin-node-resolve": "^4.2.3",
     "rollup-plugin-string": "^3.0.0",
     "rollup-plugin-terser": "^5.2.0",
-    "standard": "^12.0.1"
+    "standard": "^12.0.1",
+    "string.prototype.endswith": "^0.2.0",
+    "string.prototype.startswith": "^0.2.0"
   },
   "files": [
     "dist"

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -14,7 +14,7 @@ import inject from 'rollup-plugin-inject'
 
 // Note that postcss-selector-parser is bundled into all outputs because its deps (util.promisify)
 // cause problems depending on the consumer's bundler. We can make things simpler for consumers of
-// kagekiri by just bundling our dependencies.
+// kagekiri by just bundling our dependencies. (Polyfills are also bundled.)
 
 function config (file, format, opts = {}) {
   const plugins = opts.plugins || []

--- a/src/index.js
+++ b/src/index.js
@@ -7,6 +7,8 @@
 
 /* global Element */
 
+import 'string.prototype.startswith'
+import 'string.prototype.endswith'
 import postcssSelectorParser from 'postcss-selector-parser'
 
 // IE11 does not have Element.prototype.matches, we can use msMatchesSelector.


### PR DESCRIPTION
Includes a global polyfill for `String.prototype.startsWith` and `String.prototype.endsWith`, which aren't supported in IE.

Normally I would prefer for a library not to bundle its own polyfills which modify global Objects, but this would be very tricky to fix with Babel/Buble in a non-global-touching way, especially since this usage comes from one of our dependencies (`postcss-selector-parser)`.