### PR TITLE
test: add tests for unusual CSS selectors

### DIFF
--- a/test/fixtures/unusualSelectors1/light.html
+++ b/test/fixtures/unusualSelectors1/light.html
@@ -1,0 +1,15 @@
+<!--
+  Copyright (c) 2019, salesforce.com, inc.
+  All rights reserved.
+  SPDX-License-Identifier: BSD-3-Clause
+  For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+-->
+<body>
+  <div class="my-component">
+    <div class='double"quote' id='double"quote' data-doublequote='double"quote'></div>
+    <div class="single'quote" id="single'quote" data-singlequote="single'quote"></div>
+    <div class="uni👪code" id="uni👪code" data-uni👪code="uni👪code"></div>
+    <div class="[]bracket{}" id="[]bracket{}" data-bracket="[]bracket{}"></div>
+    <div class="hash#.dot" id="hash#.dot" data-hashdot="hash#.dot"></div>
+  </div>
+</body>

--- a/test/fixtures/unusualSelectors1/shadow.html
+++ b/test/fixtures/unusualSelectors1/shadow.html
@@ -1,0 +1,25 @@
+<!--
+  Copyright (c) 2019, salesforce.com, inc.
+  All rights reserved.
+  SPDX-License-Identifier: BSD-3-Clause
+  For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+-->
+<body>
+  <custom-component class="my-component"></custom-component>
+  <script>
+    class CustomComponent extends HTMLElement {
+      constructor() {
+        super()
+        const shadowRoot = this.attachShadow({ mode: 'open' })
+        shadowRoot.innerHTML = `
+          <div class='double"quote' id='double"quote' data-doublequote='double"quote'></div>
+          <div class="single'quote" id="single'quote" data-singlequote="single'quote"></div>
+          <div class="uni👪code" id="uni👪code" data-uni👪code="uni👪code"></div>
+          <div class="[]bracket{}" id="[]bracket{}" data-bracket="[]bracket{}"></div>
+          <div class="hash#.dot" id="hash#.dot" data-hashdot="hash#.dot"></div>
+        `
+      }
+    }
+    customElements.define('custom-component', CustomComponent)
+  </script>
+</body>

--- a/test/test.js
+++ b/test/test.js
@@ -46,6 +46,8 @@ import nestedSlotsLight6 from './fixtures/nestedSlots6/light.html'
 import nestedSlotsShadow6 from './fixtures/nestedSlots6/shadow.html'
 import nestedSlotsLight7 from './fixtures/nestedSlots7/light.html'
 import nestedSlotsShadow7 from './fixtures/nestedSlots7/shadow.html'
+import unusualSelectorsLight1 from './fixtures/unusualSelectors1/light.html'
+import unusualSelectorsShadow1 from './fixtures/unusualSelectors1/shadow.html'
 
 function withDom (html, cb) {
   const iframe = document.createElement('iframe')
@@ -891,5 +893,41 @@ describe('basic test suite', function () {
 
     withDom(simpleLight1, test(true))
     withDom(simpleShadow1, test(false))
+  })
+
+  describe('unusual selectors', () => {
+    const singleQuote = [{ tagName: 'DIV', classList: ["single'quote"] }]
+    const doubleQuote = [{ tagName: 'DIV', classList: ['double"quote'] }]
+    const unicode = [{ tagName: 'DIV', classList: ['uni👪code'] }]
+    const bracket = [{ tagName: 'DIV', classList: ['[]bracket{}'] }]
+    const hashDot = [{ tagName: 'DIV', classList: ['hash#.dot'] }]
+
+    testSelectors(unusualSelectorsLight1, unusualSelectorsShadow1, [
+      { selector: ".single\\'quote", expected: singleQuote },
+      { selector: "#single\\'quote", expected: singleQuote },
+      { selector: "[data-singlequote=\"single\\'quote\"]", expected: singleQuote },
+      { selector: "[data-singlequote='single\\'quote']", expected: singleQuote },
+
+      { selector: '.double\\"quote', expected: doubleQuote },
+      { selector: '#double\\"quote', expected: doubleQuote },
+      { selector: '[data-doublequote=\'double\\"quote\']', expected: doubleQuote },
+      { selector: '[data-doublequote="double\\"quote"]', expected: doubleQuote },
+
+      { selector: '.uni👪code', expected: unicode },
+      { selector: '#uni👪code', expected: unicode },
+      { selector: '[data-uni👪code]', expected: unicode },
+      { selector: '[data-uni👪code="uni👪code"]', expected: unicode },
+      { selector: "[data-uni👪code='uni👪code']", expected: unicode },
+
+      { selector: '.\\[\\]bracket\\{\\}', expected: bracket },
+      { selector: '#\\[\\]bracket\\{\\}', expected: bracket },
+      { selector: '[data-bracket="\\[\\]bracket\\{\\}"]', expected: bracket },
+      { selector: "[data-bracket='\\[\\]bracket\\{\\}']", expected: bracket },
+
+      { selector: '.hash\\#\\.dot', expected: hashDot },
+      { selector: '#hash\\#\\.dot', expected: hashDot },
+      { selector: '[data-hashdot="hash\\#\\.dot"]', expected: hashDot },
+      { selector: "[data-hashdot='hash\\#\\.dot']", expected: hashDot }
+    ])
   })
 })


### PR DESCRIPTION
These are just some tests to make sure that our CSS selector parser library works correctly in some unusual (but valid) cases, such as classes, IDs, and attributes containing unusual characters (quotes, double quotes, emoji, brackets, etc.).