### PR TITLE
fix: fix missing Salesforce copyright header, bump to 2020

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2019, Salesforce.com, Inc.
+Copyright (c) 2020, Salesforce.com, Inc.
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, salesforce.com, inc.
+ * Copyright (c) 2020, salesforce.com, inc.
  * All rights reserved.
  * SPDX-License-Identifier: BSD-3-Clause
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, salesforce.com, inc.
+ * Copyright (c) 2020, salesforce.com, inc.
  * All rights reserved.
  * SPDX-License-Identifier: BSD-3-Clause
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, salesforce.com, inc.
+ * Copyright (c) 2020, salesforce.com, inc.
  * All rights reserved.
  * SPDX-License-Identifier: BSD-3-Clause
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause

--- a/test/fixtures/attribute1/light.html
+++ b/test/fixtures/attribute1/light.html
@@ -1,5 +1,5 @@
 <!--
-  Copyright (c) 2019, salesforce.com, inc.
+  Copyright (c) 2020, salesforce.com, inc.
   All rights reserved.
   SPDX-License-Identifier: BSD-3-Clause
   For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause

--- a/test/fixtures/attribute1/shadow.html
+++ b/test/fixtures/attribute1/shadow.html
@@ -1,5 +1,5 @@
 <!--
-  Copyright (c) 2019, salesforce.com, inc.
+  Copyright (c) 2020, salesforce.com, inc.
   All rights reserved.
   SPDX-License-Identifier: BSD-3-Clause
   For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause

--- a/test/fixtures/attribute2/light.html
+++ b/test/fixtures/attribute2/light.html
@@ -1,5 +1,5 @@
 <!--
-  Copyright (c) 2019, salesforce.com, inc.
+  Copyright (c) 2020, salesforce.com, inc.
   All rights reserved.
   SPDX-License-Identifier: BSD-3-Clause
   For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause

--- a/test/fixtures/attribute2/shadow.html
+++ b/test/fixtures/attribute2/shadow.html
@@ -1,5 +1,5 @@
 <!--
-  Copyright (c) 2019, salesforce.com, inc.
+  Copyright (c) 2020, salesforce.com, inc.
   All rights reserved.
   SPDX-License-Identifier: BSD-3-Clause
   For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause

--- a/test/fixtures/classNames1/light.html
+++ b/test/fixtures/classNames1/light.html
@@ -1,5 +1,5 @@
 <!--
-  Copyright (c) 2019, salesforce.com, inc.
+  Copyright (c) 2020, salesforce.com, inc.
   All rights reserved.
   SPDX-License-Identifier: BSD-3-Clause
   For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause

--- a/test/fixtures/classNames1/shadow.html
+++ b/test/fixtures/classNames1/shadow.html
@@ -1,5 +1,5 @@
 <!--
-  Copyright (c) 2019, salesforce.com, inc.
+  Copyright (c) 2020, salesforce.com, inc.
   All rights reserved.
   SPDX-License-Identifier: BSD-3-Clause
   For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
@@ -16,13 +16,13 @@
                     <span class="container main outerText">Hello</spam>
                 </div>`
         }
-    
+
         connectedCallback() {
           this.setAttribute('class', 'outer')
           this.shadowRoot.querySelector('.wrapper').appendChild(new InnerComponent())
         }
       }
-    
+
       class InnerComponent extends HTMLElement {
         constructor () {
           super()
@@ -32,16 +32,15 @@
             <span class="container main innerText">Hello Inner</span>
           </div>`
         }
-    
+
         connectedCallback() {
           this.setAttribute('class', 'inner')
         }
       }
-    
+
       customElements.define('outer-component', OuterComponent)
       customElements.define('inner-component', InnerComponent)
-    
+
       document.querySelector('.container').appendChild(new OuterComponent())
     </script>
     </body>
-    

--- a/test/fixtures/deep1/light.html
+++ b/test/fixtures/deep1/light.html
@@ -1,5 +1,5 @@
 <!--
-  Copyright (c) 2019, salesforce.com, inc.
+  Copyright (c) 2020, salesforce.com, inc.
   All rights reserved.
   SPDX-License-Identifier: BSD-3-Clause
   For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause

--- a/test/fixtures/deep1/shadow.html
+++ b/test/fixtures/deep1/shadow.html
@@ -1,5 +1,5 @@
 <!--
-  Copyright (c) 2019, salesforce.com, inc.
+  Copyright (c) 2020, salesforce.com, inc.
   All rights reserved.
   SPDX-License-Identifier: BSD-3-Clause
   For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause

--- a/test/fixtures/duplicateSlots1/light.html
+++ b/test/fixtures/duplicateSlots1/light.html
@@ -1,5 +1,5 @@
 <!--
-  Copyright (c) 2019, salesforce.com, inc.
+  Copyright (c) 2020, salesforce.com, inc.
   All rights reserved.
   SPDX-License-Identifier: BSD-3-Clause
   For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause

--- a/test/fixtures/duplicateSlots1/shadow.html
+++ b/test/fixtures/duplicateSlots1/shadow.html
@@ -1,5 +1,5 @@
 <!--
-  Copyright (c) 2019, salesforce.com, inc.
+  Copyright (c) 2020, salesforce.com, inc.
   All rights reserved.
   SPDX-License-Identifier: BSD-3-Clause
   For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause

--- a/test/fixtures/id1/light.html
+++ b/test/fixtures/id1/light.html
@@ -1,5 +1,5 @@
 <!--
-  Copyright (c) 2019, salesforce.com, inc.
+  Copyright (c) 2020, salesforce.com, inc.
   All rights reserved.
   SPDX-License-Identifier: BSD-3-Clause
   For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause

--- a/test/fixtures/id1/shadow.html
+++ b/test/fixtures/id1/shadow.html
@@ -1,5 +1,5 @@
 <!--
-  Copyright (c) 2019, salesforce.com, inc.
+  Copyright (c) 2020, salesforce.com, inc.
   All rights reserved.
   SPDX-License-Identifier: BSD-3-Clause
   For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause

--- a/test/fixtures/nestedSlots1/light.html
+++ b/test/fixtures/nestedSlots1/light.html
@@ -1,5 +1,5 @@
 <!--
-  Copyright (c) 2019, salesforce.com, inc.
+  Copyright (c) 2020, salesforce.com, inc.
   All rights reserved.
   SPDX-License-Identifier: BSD-3-Clause
   For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause

--- a/test/fixtures/nestedSlots1/shadow.html
+++ b/test/fixtures/nestedSlots1/shadow.html
@@ -1,5 +1,5 @@
 <!--
-  Copyright (c) 2019, salesforce.com, inc.
+  Copyright (c) 2020, salesforce.com, inc.
   All rights reserved.
   SPDX-License-Identifier: BSD-3-Clause
   For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause

--- a/test/fixtures/nestedSlots2/light.html
+++ b/test/fixtures/nestedSlots2/light.html
@@ -1,5 +1,5 @@
 <!--
-  Copyright (c) 2019, salesforce.com, inc.
+  Copyright (c) 2020, salesforce.com, inc.
   All rights reserved.
   SPDX-License-Identifier: BSD-3-Clause
   For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause

--- a/test/fixtures/nestedSlots2/shadow.html
+++ b/test/fixtures/nestedSlots2/shadow.html
@@ -1,5 +1,5 @@
 <!--
-  Copyright (c) 2019, salesforce.com, inc.
+  Copyright (c) 2020, salesforce.com, inc.
   All rights reserved.
   SPDX-License-Identifier: BSD-3-Clause
   For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause

--- a/test/fixtures/nestedSlots3/light.html
+++ b/test/fixtures/nestedSlots3/light.html
@@ -1,5 +1,5 @@
 <!--
-  Copyright (c) 2019, salesforce.com, inc.
+  Copyright (c) 2020, salesforce.com, inc.
   All rights reserved.
   SPDX-License-Identifier: BSD-3-Clause
   For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause

--- a/test/fixtures/nestedSlots3/shadow.html
+++ b/test/fixtures/nestedSlots3/shadow.html
@@ -1,5 +1,5 @@
 <!--
-  Copyright (c) 2019, salesforce.com, inc.
+  Copyright (c) 2020, salesforce.com, inc.
   All rights reserved.
   SPDX-License-Identifier: BSD-3-Clause
   For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause

--- a/test/fixtures/nestedSlots4/light.html
+++ b/test/fixtures/nestedSlots4/light.html
@@ -1,5 +1,5 @@
 <!--
-  Copyright (c) 2019, salesforce.com, inc.
+  Copyright (c) 2020, salesforce.com, inc.
   All rights reserved.
   SPDX-License-Identifier: BSD-3-Clause
   For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause

--- a/test/fixtures/nestedSlots4/shadow.html
+++ b/test/fixtures/nestedSlots4/shadow.html
@@ -1,5 +1,5 @@
 <!--
-  Copyright (c) 2019, salesforce.com, inc.
+  Copyright (c) 2020, salesforce.com, inc.
   All rights reserved.
   SPDX-License-Identifier: BSD-3-Clause
   For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause

--- a/test/fixtures/nestedSlots5/light.html
+++ b/test/fixtures/nestedSlots5/light.html
@@ -1,5 +1,5 @@
 <!--
-  Copyright (c) 2019, salesforce.com, inc.
+  Copyright (c) 2020, salesforce.com, inc.
   All rights reserved.
   SPDX-License-Identifier: BSD-3-Clause
   For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause

--- a/test/fixtures/nestedSlots5/shadow.html
+++ b/test/fixtures/nestedSlots5/shadow.html
@@ -1,5 +1,5 @@
 <!--
-  Copyright (c) 2019, salesforce.com, inc.
+  Copyright (c) 2020, salesforce.com, inc.
   All rights reserved.
   SPDX-License-Identifier: BSD-3-Clause
   For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause

--- a/test/fixtures/nestedSlots6/light.html
+++ b/test/fixtures/nestedSlots6/light.html
@@ -1,5 +1,5 @@
 <!--
-  Copyright (c) 2019, salesforce.com, inc.
+  Copyright (c) 2020, salesforce.com, inc.
   All rights reserved.
   SPDX-License-Identifier: BSD-3-Clause
   For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause

--- a/test/fixtures/nestedSlots6/shadow.html
+++ b/test/fixtures/nestedSlots6/shadow.html
@@ -1,5 +1,5 @@
 <!--
-  Copyright (c) 2019, salesforce.com, inc.
+  Copyright (c) 2020, salesforce.com, inc.
   All rights reserved.
   SPDX-License-Identifier: BSD-3-Clause
   For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause

--- a/test/fixtures/nestedSlots7/light.html
+++ b/test/fixtures/nestedSlots7/light.html
@@ -1,5 +1,5 @@
 <!--
-  Copyright (c) 2019, salesforce.com, inc.
+  Copyright (c) 2020, salesforce.com, inc.
   All rights reserved.
   SPDX-License-Identifier: BSD-3-Clause
   For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause

--- a/test/fixtures/nestedSlots7/shadow.html
+++ b/test/fixtures/nestedSlots7/shadow.html
@@ -1,5 +1,5 @@
 <!--
-  Copyright (c) 2019, salesforce.com, inc.
+  Copyright (c) 2020, salesforce.com, inc.
   All rights reserved.
   SPDX-License-Identifier: BSD-3-Clause
   For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause

--- a/test/fixtures/ofType1/light.html
+++ b/test/fixtures/ofType1/light.html
@@ -1,5 +1,5 @@
 <!--
-  Copyright (c) 2019, salesforce.com, inc.
+  Copyright (c) 2020, salesforce.com, inc.
   All rights reserved.
   SPDX-License-Identifier: BSD-3-Clause
   For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause

--- a/test/fixtures/ofType1/shadow.html
+++ b/test/fixtures/ofType1/shadow.html
@@ -1,5 +1,5 @@
 <!--
-  Copyright (c) 2019, salesforce.com, inc.
+  Copyright (c) 2020, salesforce.com, inc.
   All rights reserved.
   SPDX-License-Identifier: BSD-3-Clause
   For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause

--- a/test/fixtures/ordering1/light.html
+++ b/test/fixtures/ordering1/light.html
@@ -1,5 +1,5 @@
 <!--
-  Copyright (c) 2019, salesforce.com, inc.
+  Copyright (c) 2020, salesforce.com, inc.
   All rights reserved.
   SPDX-License-Identifier: BSD-3-Clause
   For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause

--- a/test/fixtures/ordering1/shadow.html
+++ b/test/fixtures/ordering1/shadow.html
@@ -1,5 +1,5 @@
 <!--
-  Copyright (c) 2019, salesforce.com, inc.
+  Copyright (c) 2020, salesforce.com, inc.
   All rights reserved.
   SPDX-License-Identifier: BSD-3-Clause
   For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause

--- a/test/fixtures/sibling1/light.html
+++ b/test/fixtures/sibling1/light.html
@@ -1,5 +1,5 @@
 <!--
-  Copyright (c) 2019, salesforce.com, inc.
+  Copyright (c) 2020, salesforce.com, inc.
   All rights reserved.
   SPDX-License-Identifier: BSD-3-Clause
   For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause

--- a/test/fixtures/sibling1/shadow.html
+++ b/test/fixtures/sibling1/shadow.html
@@ -1,5 +1,5 @@
 <!--
-  Copyright (c) 2019, salesforce.com, inc.
+  Copyright (c) 2020, salesforce.com, inc.
   All rights reserved.
   SPDX-License-Identifier: BSD-3-Clause
   For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause

--- a/test/fixtures/simple1/light.html
+++ b/test/fixtures/simple1/light.html
@@ -1,5 +1,5 @@
 <!--
-  Copyright (c) 2019, salesforce.com, inc.
+  Copyright (c) 2020, salesforce.com, inc.
   All rights reserved.
   SPDX-License-Identifier: BSD-3-Clause
   For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause

--- a/test/fixtures/simple1/shadow.html
+++ b/test/fixtures/simple1/shadow.html
@@ -1,5 +1,5 @@
 <!--
-  Copyright (c) 2019, salesforce.com, inc.
+  Copyright (c) 2020, salesforce.com, inc.
   All rights reserved.
   SPDX-License-Identifier: BSD-3-Clause
   For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause

--- a/test/fixtures/slots1/light.html
+++ b/test/fixtures/slots1/light.html
@@ -1,5 +1,5 @@
 <!--
-  Copyright (c) 2019, salesforce.com, inc.
+  Copyright (c) 2020, salesforce.com, inc.
   All rights reserved.
   SPDX-License-Identifier: BSD-3-Clause
   For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause

--- a/test/fixtures/slots1/shadow.html
+++ b/test/fixtures/slots1/shadow.html
@@ -1,5 +1,5 @@
 <!--
-  Copyright (c) 2019, salesforce.com, inc.
+  Copyright (c) 2020, salesforce.com, inc.
   All rights reserved.
   SPDX-License-Identifier: BSD-3-Clause
   For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause

--- a/test/fixtures/slots2/light.html
+++ b/test/fixtures/slots2/light.html
@@ -1,5 +1,5 @@
 <!--
-  Copyright (c) 2019, salesforce.com, inc.
+  Copyright (c) 2020, salesforce.com, inc.
   All rights reserved.
   SPDX-License-Identifier: BSD-3-Clause
   For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause

--- a/test/fixtures/slots2/shadow.html
+++ b/test/fixtures/slots2/shadow.html
@@ -1,5 +1,5 @@
 <!--
-  Copyright (c) 2019, salesforce.com, inc.
+  Copyright (c) 2020, salesforce.com, inc.
   All rights reserved.
   SPDX-License-Identifier: BSD-3-Clause
   For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause

--- a/test/fixtures/slots3/light.html
+++ b/test/fixtures/slots3/light.html
@@ -1,5 +1,5 @@
 <!--
-  Copyright (c) 2019, salesforce.com, inc.
+  Copyright (c) 2020, salesforce.com, inc.
   All rights reserved.
   SPDX-License-Identifier: BSD-3-Clause
   For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause

--- a/test/fixtures/slots3/shadow.html
+++ b/test/fixtures/slots3/shadow.html
@@ -1,5 +1,5 @@
 <!--
-  Copyright (c) 2019, salesforce.com, inc.
+  Copyright (c) 2020, salesforce.com, inc.
   All rights reserved.
   SPDX-License-Identifier: BSD-3-Clause
   For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause

--- a/test/fixtures/unusualSelectors1/light.html
+++ b/test/fixtures/unusualSelectors1/light.html
@@ -1,5 +1,5 @@
 <!--
-  Copyright (c) 2019, salesforce.com, inc.
+  Copyright (c) 2020, salesforce.com, inc.
   All rights reserved.
   SPDX-License-Identifier: BSD-3-Clause
   For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause

--- a/test/fixtures/unusualSelectors1/shadow.html
+++ b/test/fixtures/unusualSelectors1/shadow.html
@@ -1,5 +1,5 @@
 <!--
-  Copyright (c) 2019, salesforce.com, inc.
+  Copyright (c) 2020, salesforce.com, inc.
   All rights reserved.
   SPDX-License-Identifier: BSD-3-Clause
   For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause

--- a/test/getElementsByClassName.spec.js
+++ b/test/getElementsByClassName.spec.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, salesforce.com, inc.
+ * Copyright (c) 2020, salesforce.com, inc.
  * All rights reserved.
  * SPDX-License-Identifier: BSD-3-Clause
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause

--- a/test/querySelector.spec.js
+++ b/test/querySelector.spec.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, salesforce.com, inc.
+ * Copyright (c) 2020, salesforce.com, inc.
  * All rights reserved.
  * SPDX-License-Identifier: BSD-3-Clause
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause

--- a/test/utils.js
+++ b/test/utils.js
@@ -1,3 +1,10 @@
+/*
+ * Copyright (c) 2020, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
 import assert from 'assert'
 
 export function withDom (html, cb) {

--- a/types/kagekiri.d.ts
+++ b/types/kagekiri.d.ts
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2020, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
 // Type definitions for kagekiri
 export function querySelector(selector: string, context?: Node): Element | null;
 export function querySelectorAll(selector: string, context?: Node): Element[];


### PR DESCRIPTION
A couple files were missing this header, and I assume we should also bump it from 2019 to 2020.