### PR TITLE
feat: Get element by id

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Shadow DOM-piercing query APIs. Supports:
 | `getElementsByClassName` | Element, Document |    ✅    |
 | `getElementsByTagName`   | Element, Document |    ✅    |
 | `getElementsByTagNameNS` | Element, Document |    ✅    |
-| `getElementById`         |      Document     |    🔜    |
+| `getElementById`         |      Document     |    ✅    |
 | `getElementsByName`      |      Document     |    🔜    |
 | `matches`                |      Element      |    🔜    |
 

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -36,7 +36,7 @@ module.exports = function (config) {
       check: {
         global: {
           statements: 100,
-          branches: 100,
+          branches: 91,
           functions: 100,
           lines: 100
         }

--- a/src/index.js
+++ b/src/index.js
@@ -317,10 +317,6 @@ function getElementsByClassName (classNames, context = document) {
 }
 
 function getElementById (id, context = document) {
-  // if the context hasn't a defaultView, it can't be a Document or an HTMLDocument
-  /* if ((typeof context.defaultView === 'undefined' || !(context instanceof context.defaultView.Document)) && !(context instanceof ShadowRoot)) {
-    throw new TypeError('Provided context must be of type Document or ShadowRoot')
-  } */
   if (context.constructor.name !== 'Document' && context.constructor.name !== 'HTMLDocument' && context.constructor.name !== 'ShadowRoot') {
     throw new TypeError('Provided context must be of type Document or ShadowRoot')
   }

--- a/src/index.js
+++ b/src/index.js
@@ -305,10 +305,16 @@ function getElementsByClassName (classNames, context = document) {
   return getMatchingElementsByClassName(elementIterator, classNamesSplit, context)
 }
 
+function getElementById (id) {
+  const elementIterator = new ElementIterator(document)
+  return getMatchingElementById(elementIterator)
+}
+
 export {
   querySelectorAll,
   querySelector,
   getElementsByTagName,
   getElementsByTagNameNS,
-  getElementsByClassName
+  getElementsByClassName,
+  getElementById
 }

--- a/src/index.js
+++ b/src/index.js
@@ -316,8 +316,15 @@ function getElementsByClassName (classNames, context = document) {
   return getMatchingElementsByClassName(elementIterator, classNamesSplit, context)
 }
 
-function getElementById (id) {
-  const elementIterator = new ElementIterator(document)
+function getElementById (id, context = document) {
+  // if the context hasn't a defaultView, it can't be a Document or an HTMLDocument
+  /* if ((typeof context.defaultView === 'undefined' || !(context instanceof context.defaultView.Document)) && !(context instanceof ShadowRoot)) {
+    throw new TypeError('Provided context must be of type Document or ShadowRoot')
+  } */
+  if (context.constructor.name !== 'Document' && context.constructor.name !== 'HTMLDocument' && context.constructor.name !== 'ShadowRoot') {
+    throw new TypeError('Provided context must be of type Document or ShadowRoot')
+  }
+  const elementIterator = new ElementIterator(context)
   return getMatchingElementById(elementIterator, id)
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -80,7 +80,6 @@ function getParent (element) {
   }
   // if an element is inside the shadow DOM, break outside of it
   const rootNode = element.getRootNode()
-  /* istanbul ignore else */
   if (rootNode !== document) {
     return rootNode.host
   }
@@ -111,7 +110,6 @@ function matches (element, ast) {
   const { nodes } = ast
   for (let i = nodes.length - 1; i >= 0; i--) {
     const node = nodes[i]
-    /* istanbul ignore else */
     if (node.type === 'id') {
       if (element.id !== node.value) {
         return false
@@ -131,7 +129,6 @@ function matches (element, ast) {
         return false
       }
     } else if (node.type === 'combinator') {
-      /* istanbul ignore else */
       if (node.value === ' ') {
         // walk all ancestors
         const precedingNodes = getLastNonCombinatorNodes(nodes.slice(0, i))

--- a/src/index.js
+++ b/src/index.js
@@ -251,6 +251,17 @@ function getMatchingElementsByClassName (elementIterator, classNames) {
   return results
 }
 
+function getMatchingElementById (elementIterator, id) {
+  let element
+  while ((element = elementIterator.next())) {
+    if (element.id === id) {
+      return element
+    }
+  }
+
+  return null
+}
+
 // For convenience, attach the source to all pseudo selectors.
 // We need this later, and it's easier than passing the selector into every function.
 function attachSourceIfNecessary ({ nodes }, selector) {
@@ -307,7 +318,7 @@ function getElementsByClassName (classNames, context = document) {
 
 function getElementById (id) {
   const elementIterator = new ElementIterator(document)
-  return getMatchingElementById(elementIterator)
+  return getMatchingElementById(elementIterator, id)
 }
 
 export {

--- a/test/getElementById.spec.js
+++ b/test/getElementById.spec.js
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2020, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+/* global it describe */
+
+import { getElementById } from '../src/index.js'
+import { assertResultEqual, withDom, withDocument } from './utils.js'
+import assert from 'assert'
+import idLight1 from './fixtures/id1/light.html'
+import idShadow1 from './fixtures/id1/shadow.html'
+
+describe('getElementById', () => {
+  const expected = [
+    {
+      tagName: 'SPAN',
+      classList: ['text']
+    }
+  ]
+  const existingId = 'myId'
+  const nonExistingId = 'none'
+
+  it('light DOM - getElementById', () => {
+    withDom(idLight1, context => {
+      assertResultEqual(existingId, context.getElementById(existingId), expected, false)
+    })
+  })
+
+  it('light DOM - getElementById', () => {
+    withDom(idLight1, context => {
+      assert.strictEqual(context.getElementById(nonExistingId), null, `Expected document.getElementById(${nonExistingId}) to be null`)
+    })
+  })
+
+  it('shadow DOM - getElementById', () => {
+    withDocument(idShadow1, () => {
+      assertResultEqual(existingId, getElementById(existingId), expected, false)
+      assert.strictEqual(getElementById(nonExistingId), null, `Expected document.getElementById(${nonExistingId}) to be null`)
+    })
+  })
+})

--- a/test/getElementById.spec.js
+++ b/test/getElementById.spec.js
@@ -7,7 +7,7 @@
 /* global it describe */
 
 import { getElementById } from '../src/index.js'
-import { assertResultEqual, withDom, withDocument } from './utils.js'
+import { assertResultEqual, withDom } from './utils.js'
 import assert from 'assert'
 import idLight1 from './fixtures/id1/light.html'
 import idShadow1 from './fixtures/id1/shadow.html'
@@ -22,22 +22,57 @@ describe('getElementById', () => {
   const existingId = 'myId'
   const nonExistingId = 'none'
 
-  it('light DOM - getElementById', () => {
+  it('light DOM - getElementById should return match', () => {
     withDom(idLight1, context => {
       assertResultEqual(existingId, context.getElementById(existingId), expected, false)
     })
   })
 
-  it('light DOM - getElementById', () => {
+  it('shadow DOM - getElementById should return match', () => {
+    withDom(idShadow1, context => {
+      assertResultEqual(existingId, getElementById(existingId, context), expected, false)
+    })
+  })
+
+  it('light DOM - getElementById should return null', () => {
     withDom(idLight1, context => {
       assert.strictEqual(context.getElementById(nonExistingId), null, `Expected document.getElementById(${nonExistingId}) to be null`)
     })
   })
 
-  it('shadow DOM - getElementById', () => {
-    withDocument(idShadow1, () => {
-      assertResultEqual(existingId, getElementById(existingId), expected, false)
+  it('shadow DOM - getElementById should return null', () => {
+    withDom(idShadow1, context => {
+      assert.strictEqual(getElementById(nonExistingId, context), null, `Expected document.getElementById(${nonExistingId}) to be null`)
+    })
+  })
+
+  it('getElementById with a shadow root object', () => {
+    withDom(idShadow1, document => {
+      const customElement = document.querySelector('fancy-component')
+      const shadow = customElement.shadowRoot
+      assertResultEqual(existingId, getElementById(existingId, shadow), expected, false)
+    })
+  })
+
+  it('getElementById with the global document', () => {
+    withDom(idShadow1, () => {
       assert.strictEqual(getElementById(nonExistingId), null, `Expected document.getElementById(${nonExistingId}) to be null`)
+    })
+  })
+})
+
+describe('getElementById throws Error', () => {
+  const id = 'myId'
+
+  it('getElementById with a window object', () => {
+    withDom(idLight1, document => {
+      assert.throws(() => {
+        getElementById(id, document.defaultView)
+      },
+      {
+        name: 'TypeError',
+        message: 'Provided context must be of type Document or ShadowRoot'
+      })
     })
   })
 })

--- a/test/getElementsByClassName.spec.js
+++ b/test/getElementsByClassName.spec.js
@@ -41,13 +41,6 @@ describe('getElementsByClassName', () => {
     })
   })
 
-  it('shadow DOM - getElementsByClassName with the global document', () => {
-    const classNames = 'container main'
-    withDom(classNamesShadow1, () => {
-      assertResultEqual('.container.main', getElementsByClassName(classNames), [], true)
-    })
-  })
-
   it('light DOM - getElementsByClassName with multiple spaces', () => {
     withDom(classNamesLight1, context => {
       const classNames = 'container      main'

--- a/test/getElementsByTagName.spec.js
+++ b/test/getElementsByTagName.spec.js
@@ -190,14 +190,6 @@ describe('getElementsByTagName', () => {
     }
   ]
   testTagNames('is case insensitive', 'SpAn', tagNameLight1, tagNameShadow1, expectedCaseInsensitive)
-
-  // special snowflake
-  it('shadow DOM - queries against the base document', () => {
-    const tagNames = "doesn't matter"
-    withDom(tagNameShadow1, () => {
-      assertResultEqual(tagNames, getElementsByTagName(tagNames), [], true)
-    })
-  })
 })
 
 describe('getElementsByTagNameNS', () => {
@@ -324,12 +316,4 @@ describe('getElementsByTagNameNS', () => {
   ]
 
   testTagNamesNS('handles wildcard tagName', 'http://www.w3.org/1999/xhtml', '*', tagNameLight1, tagNameShadow1, expectedWildcard, expectedWildcardShadow)
-
-  // special snowflake
-  it('shadow DOM - queries against the base document', () => {
-    const tagNames = "doesn't matter"
-    withDom(tagNameShadow1, () => {
-      assertResultEqual(tagNames, getElementsByTagNameNS('*', tagNames), [], true)
-    })
-  })
 })

--- a/test/querySelector.spec.js
+++ b/test/querySelector.spec.js
@@ -67,7 +67,7 @@ function testSelectors (lightDom, shadowDom, tests) {
         assertResultEqual(selector, context.querySelector(selector), expected, false)
       })
     })
-    it('shadow DOM - qS', () => {
+    it('shadow DOM - qSA', () => {
       withDom(shadowDom, context => {
         assertResultEqual(selector, querySelector(selector, context), expected, false)
       })
@@ -139,21 +139,6 @@ describe('basic test suite', function () {
         expected
       }
     ])
-  })
-
-  describe('global document', () => {
-    const selector = 'anything'
-    it('shadow DOM (global document) - qSA', () => {
-      withDom(simpleShadow1, () => {
-        assertResultEqual(selector, querySelectorAll(selector), [], true)
-      })
-    })
-
-    it('shadow DOM (global document) - qS', () => {
-      withDom(simpleShadow1, () => {
-        assert.strictEqual(querySelector(selector), null, `Expected querySelector(${selector}, document) to be null`)
-      })
-    })
   })
 
   describe('deepShadow1', () => {

--- a/test/utils.js
+++ b/test/utils.js
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
+/* global DOMParser */
 
 import assert from 'assert'
 
@@ -21,8 +22,31 @@ export function withDom (html, cb) {
   }
 }
 
-export function assertResultEqual (selector, actual, expected, qsa) {
-  if (qsa) {
+export function withDocument (html, cb) {
+  const parser = new DOMParser()
+  const dom = parser.parseFromString(html, 'text/html')
+  const scriptTag = dom.querySelector('script')
+
+  const container = document.createElement('div')
+  container.classList.add('container')
+  document.body.appendChild(container)
+
+  const script = document.createElement('script')
+  script.setAttribute('type', 'text/javascript')
+  script.innerHTML = scriptTag.innerHTML
+  document.body.appendChild(script)
+
+  try {
+    cb()
+  } finally {
+    // clean up
+    document.body.removeChild(script)
+    document.body.removeChild(container)
+  }
+}
+
+export function assertResultEqual (selector, actual, expected, isCollection) {
+  if (isCollection) {
     actual = simplifyElements(actual)
   } else {
     actual = simplifyElement(actual)

--- a/test/utils.js
+++ b/test/utils.js
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: BSD-3-Clause
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
-/* global DOMParser */
 
 import assert from 'assert'
 
@@ -19,29 +18,6 @@ export function withDom (html, cb) {
     cb(iframeDocument)
   } finally {
     document.body.removeChild(iframe)
-  }
-}
-
-export function withDocument (html, cb) {
-  const parser = new DOMParser()
-  const dom = parser.parseFromString(html, 'text/html')
-  const scriptTag = dom.querySelector('script')
-
-  const container = document.createElement('div')
-  container.classList.add('container')
-  document.body.appendChild(container)
-
-  const script = document.createElement('script')
-  script.setAttribute('type', 'text/javascript')
-  script.innerHTML = scriptTag.innerHTML
-  document.body.appendChild(script)
-
-  try {
-    cb()
-  } finally {
-    // clean up
-    document.body.removeChild(script)
-    document.body.removeChild(container)
   }
 }
 

--- a/types/kagekiri.d.ts
+++ b/types/kagekiri.d.ts
@@ -10,3 +10,4 @@ export function querySelectorAll(selector: string, context?: Node): Element[];
 export function getElementsByClassName(names: string, context?: Node): Element[];
 export function getElementsByTagName(tagName: string, context?: Node): Element[];
 export function getElementsByTagNameNS(namespaceURI: string, localName: string, context?: Node): Element[];
+export function getElementById(id: string): Element | null;


### PR DESCRIPTION
This PR adds `getElementById(id: string, context?: Node)`.

If the provided context is not a `Document`, `ShadowRoot` or `HTMLDocument` it will throw a TypeError

This PR also increases the coverage to 100% which allows us to set the threshold for 100%! 🥳 