### PR TITLE
docs: fix typescript signature for getElementById

### DIFF
--- a/types/kagekiri.d.ts
+++ b/types/kagekiri.d.ts
@@ -10,4 +10,4 @@ export function querySelectorAll(selector: string, context?: Node): Element[];
 export function getElementsByClassName(names: string, context?: Node): Element[];
 export function getElementsByTagName(tagName: string, context?: Node): Element[];
 export function getElementsByTagNameNS(namespaceURI: string, localName: string, context?: Node): Element[];
-export function getElementById(id: string): Element | null;
+export function getElementById(id: string, context?: DocumentOrShadowRoot): Element | null;


### PR DESCRIPTION
Adding the optional `context` argument.