### PR TITLE
feat: adding support for element.matches

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Shadow DOM-piercing query APIs. Supports:
 | `getElementsByTagNameNS` | Element, Document |    ✅    |
 | `getElementById`         |      Document     |    ✅    |
 | `getElementsByName`      |      Document     |    ✅    |
-| `matches`                |      Element      |    🔜    |
+| `matches`                |      Element      |    ✅    |
 
 
 Usage

--- a/src/index.js
+++ b/src/index.js
@@ -351,12 +351,12 @@ function getElementsByName (name, context = document) {
   return getMatchingElementsByName(elementIterator, name)
 }
 
-function matches (selector, element) {
-  assertIsElement(element)
+function matches (selector, context) {
+  assertIsElement(context)
   const ast = postcssSelectorParser().astSync(selector)
   attachSourceIfNecessary(ast, selector)
 
-  return matchesSelector(element, ast)
+  return matchesSelector(context, ast)
 }
 
 export {

--- a/src/index.js
+++ b/src/index.js
@@ -301,10 +301,8 @@ function assertIsDocumentOrShadowRoot (context) {
   }
 }
 
-function assertElement (element) {
-  if (element.nodeType && element.nodeType === 1) {
-    return true
-  } else {
+function assertIsElement (element) {
+  if (!element.nodeType !== 1) {
     throw new TypeError('Provided context must be of type Element')
   }
 }
@@ -354,7 +352,7 @@ function getElementsByName (name, context = document) {
 }
 
 function matches (selector, element) {
-  assertElement(element)
+  assertIsElement(element)
   return query(selector, element, false)
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -302,7 +302,7 @@ function assertIsDocumentOrShadowRoot (context) {
 }
 
 function assertIsElement (element) {
-  if (!element.nodeType !== 1) {
+  if (!element || element.nodeType !== 1) {
     throw new TypeError('Provided context must be of type Element')
   }
 }
@@ -353,8 +353,10 @@ function getElementsByName (name, context = document) {
 
 function matches (selector, element) {
   assertIsElement(element)
-  const result = query(selector, element, false)
-  return result !== null && result === element
+  const ast = postcssSelectorParser().astSync(selector)
+  attachSourceIfNecessary(ast, selector)
+
+  return matchesSelector(element, ast)
 }
 
 export {

--- a/src/index.js
+++ b/src/index.js
@@ -356,7 +356,12 @@ function matches (selector, context) {
   const ast = postcssSelectorParser().astSync(selector)
   attachSourceIfNecessary(ast, selector)
 
-  return matchesSelector(context, ast)
+  for (const node of ast.nodes) { // multiple nodes here are comma-separated
+    if (matchesSelector(context, node)) {
+      return true
+    }
+  }
+  return false
 }
 
 export {

--- a/src/index.js
+++ b/src/index.js
@@ -89,7 +89,7 @@ function getParent (element) {
 function getFirstMatchingAncestor (element, nodes) {
   let ancestor = getParent(element)
   while (ancestor) {
-    if (matches(ancestor, { nodes })) {
+    if (matchesSelector(ancestor, { nodes })) {
       return ancestor
     }
 
@@ -100,14 +100,14 @@ function getFirstMatchingAncestor (element, nodes) {
 function getFirstMatchingPreviousSibling (element, nodes) {
   let sibling = element.previousElementSibling
   while (sibling) {
-    if (matches(sibling, { nodes })) {
+    if (matchesSelector(sibling, { nodes })) {
       return sibling
     }
     sibling = sibling.previousElementSibling
   }
 }
 
-function matches (element, ast) {
+function matchesSelector (element, ast) {
   const { nodes } = ast
   for (let i = nodes.length - 1; i >= 0; i--) {
     const node = nodes[i]
@@ -146,7 +146,7 @@ function matches (element, ast) {
         // walk immediate parent only
         const precedingNodes = getLastNonCombinatorNodes(nodes.slice(0, i))
         const ancestor = getParent(element)
-        if (!ancestor || !matches(ancestor, { nodes: precedingNodes })) {
+        if (!ancestor || !matchesSelector(ancestor, { nodes: precedingNodes })) {
           return false
         } else {
           element = ancestor
@@ -156,7 +156,7 @@ function matches (element, ast) {
         // walk immediate sibling only
         const precedingNodes = getLastNonCombinatorNodes(nodes.slice(0, i))
         const sibling = element.previousElementSibling
-        if (!sibling || !matches(sibling, { nodes: precedingNodes })) {
+        if (!sibling || !matchesSelector(sibling, { nodes: precedingNodes })) {
           return false
         } else {
           i -= precedingNodes.length
@@ -181,7 +181,7 @@ function getMatchingElements (elementIterator, ast, multiple) {
   let element
   while ((element = elementIterator.next())) {
     for (const node of ast.nodes) { // multiple nodes here are comma-separated
-      if (matches(element, node)) {
+      if (matchesSelector(element, node)) {
         if (multiple) {
           results.push(element)
         } else {
@@ -301,6 +301,14 @@ function assertIsDocumentOrShadowRoot (context) {
   }
 }
 
+function assertElement (element) {
+  if (element.nodeType && element.nodeType === 1) {
+    return true
+  } else {
+    throw new TypeError('Provided context must be of type Element')
+  }
+}
+
 function query (selector, context, multiple) {
   const ast = postcssSelectorParser().astSync(selector)
   attachSourceIfNecessary(ast, selector)
@@ -345,6 +353,11 @@ function getElementsByName (name, context = document) {
   return getMatchingElementsByName(elementIterator, name)
 }
 
+function matches (selector, element) {
+  assertElement(element)
+  return query(selector, element, false)
+}
+
 export {
   querySelectorAll,
   querySelector,
@@ -352,5 +365,6 @@ export {
   getElementsByTagNameNS,
   getElementsByClassName,
   getElementById,
-  getElementsByName
+  getElementsByName,
+  matches
 }

--- a/src/index.js
+++ b/src/index.js
@@ -353,7 +353,8 @@ function getElementsByName (name, context = document) {
 
 function matches (selector, element) {
   assertIsElement(element)
-  return query(selector, element, false)
+  const result = query(selector, element, false)
+  return result !== null && result === element
 }
 
 export {

--- a/test/matches.spec.js
+++ b/test/matches.spec.js
@@ -17,7 +17,7 @@ describe(('element matches'), () => {
   it('light DOM - matches', () => {
     withDom(simpleLight1, context => {
       const element = context.querySelector(matchingSelector)
-      assert(element.matches(matchingSelector) === true)
+      assert.strictEqual(element.matches(matchingSelector), true)
     })
   })
 
@@ -34,7 +34,7 @@ describe(('element matches'), () => {
   it('light DOM - does not match', () => {
     withDom(simpleLight1, context => {
       const element = context.querySelector(matchingSelector)
-      assert(element.matches(nonMatchingSelector) === false)
+      assert.strictEqual(element.matches(nonMatchingSelector), false)
     })
   })
 

--- a/test/matches.spec.js
+++ b/test/matches.spec.js
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2020, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+/* global it describe */
+import { assertResultEqual, withDom } from './utils.js'
+import simpleLight1 from './fixtures/simple1/light.html'
+// import simpleShadow1 from './fixtures/simple1/shadow.html'
+
+describe(('element matches'), () => {
+  it('light DOM - matches', () => {
+    const selector = '.blah'
+    const expected = []
+    withDom(simpleLight1, context => {
+      assertResultEqual(selector, context.querySelectorAll(selector), expected, true)
+    })
+  })
+})

--- a/test/matches.spec.js
+++ b/test/matches.spec.js
@@ -5,16 +5,55 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 /* global it describe */
-import { assertResultEqual, withDom } from './utils.js'
+import { matches, querySelector } from '../src/index.js'
+import { withDom } from './utils.js'
 import simpleLight1 from './fixtures/simple1/light.html'
-// import simpleShadow1 from './fixtures/simple1/shadow.html'
+import simpleShadow1 from './fixtures/simple1/shadow.html'
+import assert from 'assert'
 
 describe(('element matches'), () => {
+  const selector = '.container .component span'
+
   it('light DOM - matches', () => {
-    const selector = '.blah'
-    const expected = []
     withDom(simpleLight1, context => {
-      assertResultEqual(selector, context.querySelectorAll(selector), expected, true)
+      const element = context.querySelector(selector)
+      assert.strictEqual(element.matches(selector), true)
+    })
+  })
+
+  it('shadow DOM - matches', () => {
+    withDom(simpleShadow1, context => {
+      const element = querySelector(selector, context)
+      assert(typeof element !== 'undefined')
+      assert.strictEqual(matches(selector, element), true)
+    })
+  })
+})
+
+describe('matches throws Error', () => {
+  const selector = '.container'
+
+  it('throws an error when passing in a document object', () => {
+    withDom(simpleLight1, document => {
+      assert.throws(() => {
+        matches(selector, document)
+      },
+      {
+        name: 'TypeError',
+        message: 'Provided context must be of type Element'
+      })
+    })
+  })
+
+  it('throws an error when passing in a window object', () => {
+    withDom(simpleLight1, document => {
+      assert.throws(() => {
+        matches(selector, document.defaultView)
+      },
+      {
+        name: 'TypeError',
+        message: 'Provided context must be of type Element'
+      })
     })
   })
 })

--- a/test/matches.spec.js
+++ b/test/matches.spec.js
@@ -25,7 +25,7 @@ describe(('element matches'), () => {
     withDom(simpleShadow1, context => {
       const element = querySelector(matchingSelector, context)
       assert(typeof element !== 'undefined')
-      assert(matches(matchingSelector, element) === true)
+      assert.strictEqual(matches(matchingSelector, element), true)
     })
   })
 
@@ -42,7 +42,7 @@ describe(('element matches'), () => {
     withDom(simpleShadow1, context => {
       const element = querySelector(matchingSelector, context)
       assert(typeof element !== 'undefined')
-      assert(matches(nonMatchingSelector, element) === false)
+      assert.strictEqual(matches(nonMatchingSelector, element), false)
     })
   })
 })

--- a/test/matches.spec.js
+++ b/test/matches.spec.js
@@ -12,20 +12,37 @@ import simpleShadow1 from './fixtures/simple1/shadow.html'
 import assert from 'assert'
 
 describe(('element matches'), () => {
-  const selector = '.container .component span'
+  const matchingSelector = '.container .component span'
 
   it('light DOM - matches', () => {
     withDom(simpleLight1, context => {
-      const element = context.querySelector(selector)
-      assert.strictEqual(element.matches(selector), true)
+      const element = context.querySelector(matchingSelector)
+      assert(element.matches(matchingSelector) === true)
     })
   })
 
   it('shadow DOM - matches', () => {
     withDom(simpleShadow1, context => {
-      const element = querySelector(selector, context)
+      const element = querySelector(matchingSelector, context)
       assert(typeof element !== 'undefined')
-      assert.strictEqual(matches(selector, element), true)
+      assert(matches(matchingSelector, element) === true)
+    })
+  })
+
+  const nonMatchingSelector = '.container .stuff span'
+
+  it('light DOM - does not match', () => {
+    withDom(simpleLight1, context => {
+      const element = context.querySelector(matchingSelector)
+      assert(element.matches(nonMatchingSelector) === false)
+    })
+  })
+
+  it('shadow DOM - does not match', () => {
+    withDom(simpleShadow1, context => {
+      const element = querySelector(matchingSelector, context)
+      assert(typeof element !== 'undefined')
+      assert(matches(nonMatchingSelector, element) === false)
     })
   })
 })

--- a/types/kagekiri.d.ts
+++ b/types/kagekiri.d.ts
@@ -12,3 +12,4 @@ export function getElementsByTagName(tagName: string, context?: Node): Element[]
 export function getElementsByTagNameNS(namespaceURI: string, localName: string, context?: Node): Element[];
 export function getElementById(id: string, context?: DocumentOrShadowRoot): Element | null;
 export function getElementsByName(name: string, context?: DocumentOrShadowRoot): Element[];
+export function matches(selector: string, context?: Node): boolean;

--- a/types/kagekiri.d.ts
+++ b/types/kagekiri.d.ts
@@ -12,4 +12,4 @@ export function getElementsByTagName(tagName: string, context?: Node): Element[]
 export function getElementsByTagNameNS(namespaceURI: string, localName: string, context?: Node): Element[];
 export function getElementById(id: string, context?: DocumentOrShadowRoot): Element | null;
 export function getElementsByName(name: string, context?: DocumentOrShadowRoot): Element[];
-export function matches(selector: string, context?: Node): boolean;
+export function matches(selector: string, context: Node): boolean;


### PR DESCRIPTION
With this PR we add support for a shadow piercing [`Element.matches()`](https://developer.mozilla.org/en-US/docs/Web/API/Element/matches).