### PR TITLE
docs: generate API docs from typedoc, insert in README

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules
 dist
 coverage
 .DS_Store
+typedoc

--- a/README.md
+++ b/README.md
@@ -88,6 +88,218 @@ kagekiri.querySelector('my-component .hello')   // <span> 😃
 kagekiri.querySelector('my-component > .hello') // <span> 😃
 ```
 
+<!-- begin API -->
+
+
+## API
+
+### closest
+
+▸ **closest**(`selector`: string, `context`: Node): Element \| null
+
+
+
+Find the closest ancestor of an element (or the element itself) matching the given CSS selector. Analogous to
+[`Element.closest`](https://developer.mozilla.org/en-US/docs/Web/API/Element/closest)
+
+#### Parameters:
+
+Name | Type | Description |
+------ | ------ | ------ |
+`selector` | string | CSS selector |
+`context` | Node | target element to match against, and whose ancestors to match against  |
+
+**Returns:** Element \| null
+
+___
+
+### getElementById
+
+▸ **getElementById**(`id`: string, `context?`: DocumentOrShadowRoot): Element \| null
+
+
+
+Query for an element matching the given ID, or null if not found. Analogous to
+[`Document.getElementById`](https://developer.mozilla.org/en-US/docs/Web/API/Document/getElementById)
+
+The default `context` is `document`. Choose another DocumentOrShadowRoot to query within that context.
+
+#### Parameters:
+
+Name | Type | Description |
+------ | ------ | ------ |
+`id` | string | element ID |
+`context?` | DocumentOrShadowRoot | context to query in, or `document` by default  |
+
+**Returns:** Element \| null
+
+___
+
+### getElementsByClassName
+
+▸ **getElementsByClassName**(`names`: string, `context?`: Node): Element[]
+
+
+
+Query for all elements matching a given class name, or multiple if a whitespace-separated list is provided.
+Analogous to
+[`Document.getElementsByClassName`](https://developer.mozilla.org/en-US/docs/Web/API/Document/getElementsByClassName).
+
+Unlike the standard API, this returns a static array of Elements rather than a live HTMLCollection.
+
+The default `context` is `document`. Choose another node to query within that context.
+
+#### Parameters:
+
+Name | Type | Description |
+------ | ------ | ------ |
+`names` | string | class name or whitespace-separated class names |
+`context?` | Node | context to query in, or `document` by default  |
+
+**Returns:** Element[]
+
+___
+
+### getElementsByName
+
+▸ **getElementsByName**(`name`: string, `context?`: DocumentOrShadowRoot): Element[]
+
+
+
+Query for all elements matching a given name. Analogous to
+[`Document.getElementsByName`](https://developer.mozilla.org/en-US/docs/Web/API/Document/getElementsByName)
+
+The default `context` is `document`. Choose another DocumentOrShadowRoot to query within that context.
+
+Unlike the standard API, this returns a static array of Elements rather than a live NodeList.
+
+#### Parameters:
+
+Name | Type | Description |
+------ | ------ | ------ |
+`name` | string | element name attribute |
+`context?` | DocumentOrShadowRoot | context to query in, or `document` by default  |
+
+**Returns:** Element[]
+
+___
+
+### getElementsByTagName
+
+▸ **getElementsByTagName**(`tagName`: string, `context?`: Node): Element[]
+
+
+
+Query for all elements matching a given tag name. Analogous to
+[`Document.getElementsByTagName`](https://developer.mozilla.org/en-US/docs/Web/API/Document/getElementsByTagName).
+The `"*"` query is supported.
+
+Unlike the standard API, this returns a static array of Elements rather than a live HTMLCollection.
+
+The default `context` is `document`. Choose another node to query within that context.
+
+#### Parameters:
+
+Name | Type | Description |
+------ | ------ | ------ |
+`tagName` | string | name of the element tag |
+`context?` | Node | context to query in, or `document` by default  |
+
+**Returns:** Element[]
+
+___
+
+### getElementsByTagNameNS
+
+▸ **getElementsByTagNameNS**(`namespaceURI`: string, `localName`: string, `context?`: Node): Element[]
+
+
+
+Query for all elements matching a given tag name and namespace. Analogous to
+[`Document.getElementsByTagNameNS`](https://developer.mozilla.org/en-US/docs/Web/API/Document/getElementsByTagNameNS).
+The `"*"` query is supported.
+
+Unlike the standard API, this returns a static array of Elements rather than a live NodeList.
+
+The default `context` is `document`. Choose another node to query within that context.
+
+#### Parameters:
+
+Name | Type | Description |
+------ | ------ | ------ |
+`namespaceURI` | string | namespace URI, or `"*"` for all |
+`localName` | string | local name, or `"*"` for all |
+`context?` | Node | context to query in, or `document` by default  |
+
+**Returns:** Element[]
+
+___
+
+### matches
+
+▸ **matches**(`selector`: string, `context`: Node): boolean
+
+
+
+Return true if the given Node matches the given CSS selector, or false otherwise. Analogous to
+[`Element.closest`](https://developer.mozilla.org/en-US/docs/Web/API/Element/closest)
+
+#### Parameters:
+
+Name | Type | Description |
+------ | ------ | ------ |
+`selector` | string | CSS selector |
+`context` | Node | element to match against  |
+
+**Returns:** boolean
+
+___
+
+### querySelector
+
+▸ **querySelector**(`selector`: string, `context?`: Node): Element \| null
+
+
+
+Query for a single element matching the CSS selector, or return null if not found. Analogous to
+[`Document.querySelector`](https://developer.mozilla.org/en-US/docs/Web/API/Document/querySelector)
+
+The default `context` is `document`. Choose another element or DocumentOrShadowRoot to query within that context.
+
+#### Parameters:
+
+Name | Type | Description |
+------ | ------ | ------ |
+`selector` | string | CSS selector |
+`context?` | Node | context to query in, or `document` by default  |
+
+**Returns:** Element \| null
+
+___
+
+### querySelectorAll
+
+▸ **querySelectorAll**(`selector`: string, `context?`: Node): Element[]
+
+
+
+Query for all elements matching a CSS selector. Analogous to
+[`Document.querySelectorAll`](https://developer.mozilla.org/en-US/docs/Web/API/Document/querySelectorAll)
+
+The default `context` is `document`. Choose another node to query within that context.
+
+#### Parameters:
+
+Name | Type | Description |
+------ | ------ | ------ |
+`selector` | string | CSS selector |
+`context?` | Node | context to query in, or `document` by default  |
+
+**Returns:** Element[]
+
+
+<!-- end API -->
+
 How it works
 ---
 
@@ -111,6 +323,12 @@ Build
 
 ```sh
 npm run build
+```
+
+Build TypeScript-based API docs using `kagekiri.d.ts`, inject them into the README:
+
+```sh
+npm run typedoc
 ```
 
 Test

--- a/package-lock.json
+++ b/package-lock.json
@@ -566,6 +566,12 @@
       "integrity": "sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ==",
       "dev": true
     },
+    "at-least-node": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz",
+      "integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==",
+      "dev": true
+    },
     "available-typed-arrays": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.2.tgz",
@@ -2608,6 +2614,19 @@
         "pify": "^3.0.0"
       }
     },
+    "handlebars": {
+      "version": "4.7.6",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.6.tgz",
+      "integrity": "sha512-1f2BACcBfiwAfStCKZNrUCgqNZkGsAT7UM3kkYtXuLo0KnaVfjKOyf7PRzB6++aK9STyT1Pd2ZCPe3EGOXleXA==",
+      "dev": true,
+      "requires": {
+        "minimist": "^1.2.5",
+        "neo-async": "^2.6.0",
+        "source-map": "^0.6.1",
+        "uglify-js": "^3.1.4",
+        "wordwrap": "^1.0.0"
+      }
+    },
     "has": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
@@ -2671,6 +2690,12 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
       "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
+      "dev": true
+    },
+    "highlight.js": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.2.0.tgz",
+      "integrity": "sha512-OryzPiqqNCfO/wtFo619W+nPYALM6u7iCQkum4bqRmmlcTikOkmlL06i009QelynBPAlNByTQU6cBB2cOBQtCw==",
       "dev": true
     },
     "hosted-git-info": {
@@ -3028,6 +3053,12 @@
           }
         }
       }
+    },
+    "interpret": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.4.0.tgz",
+      "integrity": "sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA==",
+      "dev": true
     },
     "invariant": {
       "version": "2.2.4",
@@ -3973,6 +4004,12 @@
         "js-tokens": "^3.0.0 || ^4.0.0"
       }
     },
+    "lunr": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/lunr/-/lunr-2.3.9.tgz",
+      "integrity": "sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow==",
+      "dev": true
+    },
     "magic-string": {
       "version": "0.25.7",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.7.tgz",
@@ -3998,6 +4035,12 @@
           "dev": true
         }
       }
+    },
+    "marked": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-1.2.0.tgz",
+      "integrity": "sha512-tiRxakgbNPBr301ihe/785NntvYyhxlqcL3YaC8CaxJQh7kiaEtrN9B/eK2I2943Yjkh5gw25chYFDQhOMCwMA==",
+      "dev": true
     },
     "media-typer": {
       "version": "0.3.0",
@@ -4386,6 +4429,12 @@
       "version": "0.6.2",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.2.tgz",
       "integrity": "sha512-hZXc7K2e+PgeI1eDBe/10Ard4ekbfrrqG8Ep+8Jmf4JID2bNg7NvCPOZN+kfF574pFQI7mum2AUqDidoKqcTOw==",
+      "dev": true
+    },
+    "neo-async": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
+      "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
       "dev": true
     },
     "nice-try": {
@@ -5150,6 +5199,15 @@
         "picomatch": "^2.2.1"
       }
     },
+    "rechoir": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
+      "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
+      "dev": true,
+      "requires": {
+        "resolve": "^1.1.6"
+      }
+    },
     "regenerate": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.4.1.tgz",
@@ -5476,6 +5534,17 @@
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
       "dev": true
+    },
+    "shelljs": {
+      "version": "0.8.4",
+      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.4.tgz",
+      "integrity": "sha512-7gk3UZ9kOfPLIAbslLzyWeGiEqx9e3rxwZM0KE6EL8GlGwjym9Mrlx5/p33bWTu9YG6vcS4MBxYZDHYr5lr8BQ==",
+      "dev": true,
+      "requires": {
+        "glob": "^7.0.0",
+        "interpret": "^1.0.0",
+        "rechoir": "^0.6.2"
+      }
     },
     "signal-exit": {
       "version": "3.0.3",
@@ -6148,11 +6217,94 @@
         "mime-types": "~2.1.24"
       }
     },
+    "typedoc": {
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.19.2.tgz",
+      "integrity": "sha512-oDEg1BLEzi1qvgdQXc658EYgJ5qJLVSeZ0hQ57Eq4JXy6Vj2VX4RVo18qYxRWz75ifAaYuYNBUCnbhjd37TfOg==",
+      "dev": true,
+      "requires": {
+        "fs-extra": "^9.0.1",
+        "handlebars": "^4.7.6",
+        "highlight.js": "^10.2.0",
+        "lodash": "^4.17.20",
+        "lunr": "^2.3.9",
+        "marked": "^1.1.1",
+        "minimatch": "^3.0.0",
+        "progress": "^2.0.3",
+        "semver": "^7.3.2",
+        "shelljs": "^0.8.4",
+        "typedoc-default-themes": "^0.11.4"
+      },
+      "dependencies": {
+        "fs-extra": {
+          "version": "9.0.1",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.0.1.tgz",
+          "integrity": "sha512-h2iAoN838FqAFJY2/qVpzFXy+EBxfVE220PalAqQLDVsFOHLJrZvut5puAbCdNv6WJk+B8ihI+k0c7JK5erwqQ==",
+          "dev": true,
+          "requires": {
+            "at-least-node": "^1.0.0",
+            "graceful-fs": "^4.2.0",
+            "jsonfile": "^6.0.1",
+            "universalify": "^1.0.0"
+          }
+        },
+        "jsonfile": {
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.0.1.tgz",
+          "integrity": "sha512-jR2b5v7d2vIOust+w3wtFKZIfpC2pnRmFAhAC/BuweZFQR8qZzxH1OyrQ10HmdVYiXWkYUqPVsz91cG7EL2FBg==",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.6",
+            "universalify": "^1.0.0"
+          }
+        },
+        "semver": {
+          "version": "7.3.2",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
+          "integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==",
+          "dev": true
+        },
+        "universalify": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/universalify/-/universalify-1.0.0.tgz",
+          "integrity": "sha512-rb6X1W158d7pRQBg5gkR8uPaSfiids68LTJQYOtEUhoJUWBdaQHsuT/EUduxXYxcrt4r5PJ4fuHW1MHT6p0qug==",
+          "dev": true
+        }
+      }
+    },
+    "typedoc-default-themes": {
+      "version": "0.11.4",
+      "resolved": "https://registry.npmjs.org/typedoc-default-themes/-/typedoc-default-themes-0.11.4.tgz",
+      "integrity": "sha512-Y4Lf+qIb9NTydrexlazAM46SSLrmrQRqWiD52593g53SsmUFioAsMWt8m834J6qsp+7wHRjxCXSZeiiW5cMUdw==",
+      "dev": true
+    },
+    "typedoc-plugin-markdown": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/typedoc-plugin-markdown/-/typedoc-plugin-markdown-3.0.3.tgz",
+      "integrity": "sha512-cVa9BUkJw5IeadihNDlTy4e5yq1T0ZpNXzc+/vkgxdVJwgt1BQVQHSZYUNDa2R8nrlYmP9yt3ZQDxG9nIg4++A==",
+      "dev": true,
+      "requires": {
+        "handlebars": "^4.7.6"
+      }
+    },
+    "typescript": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.0.3.tgz",
+      "integrity": "sha512-tEu6DGxGgRJPb/mVPIZ48e69xCn2yRmCgYmDugAVwmJ6o+0u1RI18eO7E7WBTLYLaEVVOhwQmcdhQHweux/WPg==",
+      "dev": true
+    },
     "ua-parser-js": {
       "version": "0.7.21",
       "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.21.tgz",
       "integrity": "sha512-+O8/qh/Qj8CgC6eYBVBykMrNtp5Gebn4dlGD/kKXVkJNDwyrAwSIqwz8CDf+tsAIWVycKcku6gIXJ0qwx/ZXaQ==",
       "dev": true
+    },
+    "uglify-js": {
+      "version": "3.11.0",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.11.0.tgz",
+      "integrity": "sha512-e1KQFRCpOxnrJsJVqDUCjURq+wXvIn7cK2sRAx9XL3HYLL9aezOP4Pb1+Y3/o693EPk111Yj2Q+IUXxcpHlygQ==",
+      "dev": true,
+      "optional": true
     },
     "unicode-canonical-property-names-ecmascript": {
       "version": "1.0.4",
@@ -6311,6 +6463,12 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
       "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
+      "dev": true
+    },
+    "wordwrap": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+      "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
       "dev": true
     },
     "workerpool": {

--- a/package.json
+++ b/package.json
@@ -10,9 +10,10 @@
     "test:debug": "karma start --browsers=Chrome --single-run=false",
     "test:bundlesize": "bundlesize",
     "build": "rollup -c",
+    "typedoc": "rimraf typedoc && typedoc --includeDeclarations --excludeExternals --plugin typedoc-plugin-markdown --out typedoc ./types && node ./scripts/copy-typedoc-to-readme.js && rimraf typedoc",
     "prepare": "npm run build",
-    "lint": "standard *.js src/**/*.js test/**/*.js",
-    "lint:fix": "standard --fix *.js src/**/*.js test/**/*.js"
+    "lint": "standard *.js {scripts,src,test}/**/*.js",
+    "lint:fix": "standard --fix *.js  {scripts,src,test}/**/*.js"
   },
   "keywords": [
     "shadowdom",
@@ -47,6 +48,7 @@
     "mocha": "^8.1.3",
     "object-assign": "^4.1.1",
     "postcss-selector-parser": "^6.0.3",
+    "rimraf": "^3.0.2",
     "rollup": "^2.26.11",
     "rollup-plugin-istanbul": "^2.0.1",
     "rollup-plugin-node-globals": "^1.4.0",
@@ -54,7 +56,10 @@
     "rollup-plugin-terser": "^7.0.2",
     "standard": "^14.3.4",
     "string.prototype.endswith": "^0.2.0",
-    "string.prototype.startswith": "^0.2.0"
+    "string.prototype.startswith": "^0.2.0",
+    "typedoc": "^0.19.2",
+    "typedoc-plugin-markdown": "^3.0.3",
+    "typescript": "^4.0.3"
   },
   "files": [
     "dist",

--- a/scripts/copy-typedoc-to-readme.js
+++ b/scripts/copy-typedoc-to-readme.js
@@ -1,0 +1,30 @@
+const fs = require('fs')
+const { promisify } = require('util')
+const readFile = promisify(fs.readFile)
+const writeFile = promisify(fs.writeFile)
+
+const START_MARKER = '<!-- begin API -->'
+const END_MARKER = '<!-- end API -->'
+
+// Take the typedoc output and insert it directly into the README
+async function main () {
+  let api = await readFile('./typedoc/modules/_kagekiri_d_.md', 'utf8')
+  api = api.substring(api.indexOf('\n## Functions'))
+  api = api.replace('## Functions', '## API')
+  api = api.replace(/\*Defined in .*?\*/g, '')
+
+  let readme = await readFile('./README.md', 'utf8')
+  const startIdx = readme.indexOf(START_MARKER)
+  const endIdx = readme.indexOf(END_MARKER)
+
+  readme = readme.substring(0, startIdx) +
+    `${START_MARKER}\n\n${api}\n\n${END_MARKER}` +
+    readme.substring(endIdx + END_MARKER.length)
+
+  await writeFile('./README.md', readme, 'utf8')
+}
+
+main().catch(err => {
+  console.error(err)
+  process.exit(1)
+})

--- a/types/kagekiri.d.ts
+++ b/types/kagekiri.d.ts
@@ -4,13 +4,111 @@
  * SPDX-License-Identifier: BSD-3-Clause
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
-// Type definitions for kagekiri
+
+/**
+ * Query for a single element matching the CSS selector, or return null if not found. Analogous to
+ * [`Document.querySelector`](https://developer.mozilla.org/en-US/docs/Web/API/Document/querySelector)
+ *
+ * The default `context` is `document`. Choose another element or DocumentOrShadowRoot to query within that context.
+ *
+ * @param selector - CSS selector
+ * @param context - context to query in, or `document` by default
+ */
 export function querySelector(selector: string, context?: Node): Element | null;
+
+/**
+ * Query for all elements matching a CSS selector. Analogous to
+ * [`Document.querySelectorAll`](https://developer.mozilla.org/en-US/docs/Web/API/Document/querySelectorAll)
+ *
+ * The default `context` is `document`. Choose another node to query within that context.
+ *
+ * @param selector - CSS selector
+ * @param context - context to query in, or `document` by default
+ */
 export function querySelectorAll(selector: string, context?: Node): Element[];
+
+/**
+ * Query for all elements matching a given class name, or multiple if a whitespace-separated list is provided.
+ * Analogous to
+ * [`Document.getElementsByClassName`](https://developer.mozilla.org/en-US/docs/Web/API/Document/getElementsByClassName).
+ *
+ * Unlike the standard API, this returns a static array of Elements rather than a live HTMLCollection.
+ *
+ * The default `context` is `document`. Choose another node to query within that context.
+ *
+ * @param names - class name or whitespace-separated class names
+ * @param context - context to query in, or `document` by default
+ */
 export function getElementsByClassName(names: string, context?: Node): Element[];
+
+
+/**
+ * Query for all elements matching a given tag name. Analogous to
+ * [`Document.getElementsByTagName`](https://developer.mozilla.org/en-US/docs/Web/API/Document/getElementsByTagName).
+ * The `"*"` query is supported.
+ *
+ * Unlike the standard API, this returns a static array of Elements rather than a live HTMLCollection.
+ *
+ * The default `context` is `document`. Choose another node to query within that context.
+ *
+ * @param tagName - name of the element tag
+ * @param context - context to query in, or `document` by default
+ */
 export function getElementsByTagName(tagName: string, context?: Node): Element[];
+
+/**
+ * Query for all elements matching a given tag name and namespace. Analogous to
+ * [`Document.getElementsByTagNameNS`](https://developer.mozilla.org/en-US/docs/Web/API/Document/getElementsByTagNameNS).
+ * The `"*"` query is supported.
+ *
+ * Unlike the standard API, this returns a static array of Elements rather than a live NodeList.
+ *
+ * The default `context` is `document`. Choose another node to query within that context.
+ *
+ * @param namespaceURI - namespace URI, or `"*"` for all
+ * @param localName - local name, or `"*"` for all
+ * @param context - context to query in, or `document` by default
+ */
 export function getElementsByTagNameNS(namespaceURI: string, localName: string, context?: Node): Element[];
+
+/**
+ * Query for an element matching the given ID, or null if not found. Analogous to
+ * [`Document.getElementById`](https://developer.mozilla.org/en-US/docs/Web/API/Document/getElementById)
+ *
+ * The default `context` is `document`. Choose another DocumentOrShadowRoot to query within that context.
+ *
+ * @param id - element ID
+ * @param context - context to query in, or `document` by default
+ */
 export function getElementById(id: string, context?: DocumentOrShadowRoot): Element | null;
+
+/**
+ * Query for all elements matching a given name. Analogous to
+ * [`Document.getElementsByName`](https://developer.mozilla.org/en-US/docs/Web/API/Document/getElementsByName)
+ *
+ * The default `context` is `document`. Choose another DocumentOrShadowRoot to query within that context.
+ *
+ * Unlike the standard API, this returns a static array of Elements rather than a live NodeList.
+ *
+ * @param name - element name attribute
+ * @param context - context to query in, or `document` by default
+ */
 export function getElementsByName(name: string, context?: DocumentOrShadowRoot): Element[];
+
+/**
+ * Return true if the given Node matches the given CSS selector, or false otherwise. Analogous to
+ * [`Element.closest`](https://developer.mozilla.org/en-US/docs/Web/API/Element/closest)
+ *
+ * @param selector - CSS selector
+ * @param context - element to match against
+ */
 export function matches(selector: string, context: Node): boolean;
-export function closest(selector: string, context?: Node): Element | null;
+
+/**
+ * Find the closest ancestor of an element (or the element itself) matching the given CSS selector. Analogous to
+ * [`Element.closest`](https://developer.mozilla.org/en-US/docs/Web/API/Element/closest)
+ *
+ * @param selector - CSS selector
+ * @param context - target element to match against, and whose ancestors to match against
+ */
+export function closest(selector: string, context: Node): Element | null;


### PR DESCRIPTION
Generates markdown API docs using `typedoc` (based on `kagekiri.d.ts`) and inserts them into the README. Makes it so we only have to update `kagekiri.d.ts` and the docs flow from there.

I didn't make it part of `npm run build` because it seems like something we'd only occasionally have to do, and it takes a bit of time to run.