### PR TITLE
docs: rename `context` to `element` for `closest` and `matches`

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ kagekiri.querySelector('my-component > .hello') // <span> 😃
 
 ### closest
 
-▸ **closest**(`selector`: string, `context`: Node): Element \| null
+▸ **closest**(`selector`: string, `element`: Node): Element \| null
 
 
 
@@ -107,7 +107,7 @@ Find the closest ancestor of an element (or the element itself) matching the giv
 Name | Type | Description |
 ------ | ------ | ------ |
 `selector` | string | CSS selector |
-`context` | Node | target element to match against, and whose ancestors to match against  |
+`element` | Node | target element to match against, and whose ancestors to match against  |
 
 **Returns:** Element \| null
 
@@ -237,7 +237,7 @@ ___
 
 ### matches
 
-▸ **matches**(`selector`: string, `context`: Node): boolean
+▸ **matches**(`selector`: string, `element`: Node): boolean
 
 
 
@@ -249,7 +249,7 @@ Return true if the given Node matches the given CSS selector, or false otherwise
 Name | Type | Description |
 ------ | ------ | ------ |
 `selector` | string | CSS selector |
-`context` | Node | element to match against  |
+`element` | Node | element to match against  |
 
 **Returns:** boolean
 

--- a/src/index.js
+++ b/src/index.js
@@ -356,27 +356,27 @@ function getElementsByName (name, context = document) {
   return getMatchingElementsByName(elementIterator, name)
 }
 
-function matches (selector, context) {
-  assertIsElement(context)
+function matches (selector, element) {
+  assertIsElement(element)
   const ast = parse(selector)
 
   for (const node of ast.nodes) { // comma-separated selectors, e.g. .foo, .bar
-    if (matchesSelector(context, node)) {
+    if (matchesSelector(element, node)) {
       return true
     }
   }
   return false
 }
 
-function closest (selector, context) {
+function closest (selector, element) {
   const ast = parse(selector)
 
   for (const node of ast.nodes) { // comma-separated selectors, e.g. .foo, .bar
-    if (matchesSelector(context, node)) {
-      return context
+    if (matchesSelector(element, node)) {
+      return element
     }
 
-    const matchingAncestor = getFirstMatchingAncestor(context, node.nodes)
+    const matchingAncestor = getFirstMatchingAncestor(element, node.nodes)
     if (matchingAncestor) {
       return matchingAncestor
     }

--- a/types/kagekiri.d.ts
+++ b/types/kagekiri.d.ts
@@ -100,15 +100,15 @@ export function getElementsByName(name: string, context?: DocumentOrShadowRoot):
  * [`Element.closest`](https://developer.mozilla.org/en-US/docs/Web/API/Element/closest)
  *
  * @param selector - CSS selector
- * @param context - element to match against
+ * @param element - element to match against
  */
-export function matches(selector: string, context: Node): boolean;
+export function matches(selector: string, element: Node): boolean;
 
 /**
  * Find the closest ancestor of an element (or the element itself) matching the given CSS selector. Analogous to
  * [`Element.closest`](https://developer.mozilla.org/en-US/docs/Web/API/Element/closest)
  *
  * @param selector - CSS selector
- * @param context - target element to match against, and whose ancestors to match against
+ * @param element - target element to match against, and whose ancestors to match against
  */
-export function closest(selector: string, context: Node): Element | null;
+export function closest(selector: string, element: Node): Element | null;


### PR DESCRIPTION
Per discussion in #49 