### PR TITLE
fix: update typedoc/marked

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,9 +95,7 @@ kagekiri.querySelector('my-component > .hello') // <span> 😃
 
 ### closest
 
-▸ **closest**(`selector`: string, `element`: Node): Element \| null
-
-
+▸ **closest**(`selector`: *string*, `element`: Node): Element \| *null*
 
 Find the closest ancestor of an element (or the element itself) matching the given CSS selector. Analogous to
 [`Element.closest`](https://developer.mozilla.org/en-US/docs/Web/API/Element/closest)
@@ -105,19 +103,17 @@ Find the closest ancestor of an element (or the element itself) matching the giv
 #### Parameters:
 
 Name | Type | Description |
------- | ------ | ------ |
-`selector` | string | CSS selector |
-`element` | Node | target element to match against, and whose ancestors to match against  |
+:------ | :------ | :------ |
+`selector` | *string* | CSS selector   |
+`element` | Node | target element to match against, and whose ancestors to match against    |
 
-**Returns:** Element \| null
+**Returns:** Element \| *null*
 
 ___
 
 ### getElementById
 
-▸ **getElementById**(`id`: string, `context?`: DocumentOrShadowRoot): Element \| null
-
-
+▸ **getElementById**(`id`: *string*, `context?`: DocumentOrShadowRoot): Element \| *null*
 
 Query for an element matching the given ID, or null if not found. Analogous to
 [`Document.getElementById`](https://developer.mozilla.org/en-US/docs/Web/API/Document/getElementById)
@@ -127,19 +123,17 @@ The default `context` is `document`. Choose another DocumentOrShadowRoot to quer
 #### Parameters:
 
 Name | Type | Description |
------- | ------ | ------ |
-`id` | string | element ID |
-`context?` | DocumentOrShadowRoot | context to query in, or `document` by default  |
+:------ | :------ | :------ |
+`id` | *string* | element ID   |
+`context?` | DocumentOrShadowRoot | context to query in, or `document` by default    |
 
-**Returns:** Element \| null
+**Returns:** Element \| *null*
 
 ___
 
 ### getElementsByClassName
 
-▸ **getElementsByClassName**(`names`: string, `context?`: Node): Element[]
-
-
+▸ **getElementsByClassName**(`names`: *string*, `context?`: Node): Element[]
 
 Query for all elements matching a given class name, or multiple if a whitespace-separated list is provided.
 Analogous to
@@ -152,9 +146,9 @@ The default `context` is `document`. Choose another node to query within that co
 #### Parameters:
 
 Name | Type | Description |
------- | ------ | ------ |
-`names` | string | class name or whitespace-separated class names |
-`context?` | Node | context to query in, or `document` by default  |
+:------ | :------ | :------ |
+`names` | *string* | class name or whitespace-separated class names   |
+`context?` | Node | context to query in, or `document` by default    |
 
 **Returns:** Element[]
 
@@ -162,9 +156,7 @@ ___
 
 ### getElementsByName
 
-▸ **getElementsByName**(`name`: string, `context?`: DocumentOrShadowRoot): Element[]
-
-
+▸ **getElementsByName**(`name`: *string*, `context?`: DocumentOrShadowRoot): Element[]
 
 Query for all elements matching a given name. Analogous to
 [`Document.getElementsByName`](https://developer.mozilla.org/en-US/docs/Web/API/Document/getElementsByName)
@@ -176,9 +168,9 @@ Unlike the standard API, this returns a static array of Elements rather than a l
 #### Parameters:
 
 Name | Type | Description |
------- | ------ | ------ |
-`name` | string | element name attribute |
-`context?` | DocumentOrShadowRoot | context to query in, or `document` by default  |
+:------ | :------ | :------ |
+`name` | *string* | element name attribute   |
+`context?` | DocumentOrShadowRoot | context to query in, or `document` by default    |
 
 **Returns:** Element[]
 
@@ -186,9 +178,7 @@ ___
 
 ### getElementsByTagName
 
-▸ **getElementsByTagName**(`tagName`: string, `context?`: Node): Element[]
-
-
+▸ **getElementsByTagName**(`tagName`: *string*, `context?`: Node): Element[]
 
 Query for all elements matching a given tag name. Analogous to
 [`Document.getElementsByTagName`](https://developer.mozilla.org/en-US/docs/Web/API/Document/getElementsByTagName).
@@ -201,9 +191,9 @@ The default `context` is `document`. Choose another node to query within that co
 #### Parameters:
 
 Name | Type | Description |
------- | ------ | ------ |
-`tagName` | string | name of the element tag |
-`context?` | Node | context to query in, or `document` by default  |
+:------ | :------ | :------ |
+`tagName` | *string* | name of the element tag   |
+`context?` | Node | context to query in, or `document` by default    |
 
 **Returns:** Element[]
 
@@ -211,9 +201,7 @@ ___
 
 ### getElementsByTagNameNS
 
-▸ **getElementsByTagNameNS**(`namespaceURI`: string, `localName`: string, `context?`: Node): Element[]
-
-
+▸ **getElementsByTagNameNS**(`namespaceURI`: *string*, `localName`: *string*, `context?`: Node): Element[]
 
 Query for all elements matching a given tag name and namespace. Analogous to
 [`Document.getElementsByTagNameNS`](https://developer.mozilla.org/en-US/docs/Web/API/Document/getElementsByTagNameNS).
@@ -226,10 +214,10 @@ The default `context` is `document`. Choose another node to query within that co
 #### Parameters:
 
 Name | Type | Description |
------- | ------ | ------ |
-`namespaceURI` | string | namespace URI, or `"*"` for all |
-`localName` | string | local name, or `"*"` for all |
-`context?` | Node | context to query in, or `document` by default  |
+:------ | :------ | :------ |
+`namespaceURI` | *string* | namespace URI, or `"*"` for all   |
+`localName` | *string* | local name, or `"*"` for all   |
+`context?` | Node | context to query in, or `document` by default    |
 
 **Returns:** Element[]
 
@@ -237,9 +225,7 @@ ___
 
 ### matches
 
-▸ **matches**(`selector`: string, `element`: Node): boolean
-
-
+▸ **matches**(`selector`: *string*, `element`: Node): *boolean*
 
 Return true if the given Node matches the given CSS selector, or false otherwise. Analogous to
 [`Element.closest`](https://developer.mozilla.org/en-US/docs/Web/API/Element/closest)
@@ -247,19 +233,17 @@ Return true if the given Node matches the given CSS selector, or false otherwise
 #### Parameters:
 
 Name | Type | Description |
------- | ------ | ------ |
-`selector` | string | CSS selector |
-`element` | Node | element to match against  |
+:------ | :------ | :------ |
+`selector` | *string* | CSS selector   |
+`element` | Node | element to match against    |
 
-**Returns:** boolean
+**Returns:** *boolean*
 
 ___
 
 ### querySelector
 
-▸ **querySelector**(`selector`: string, `context?`: Node): Element \| null
-
-
+▸ **querySelector**(`selector`: *string*, `context?`: Node): Element \| *null*
 
 Query for a single element matching the CSS selector, or return null if not found. Analogous to
 [`Document.querySelector`](https://developer.mozilla.org/en-US/docs/Web/API/Document/querySelector)
@@ -269,19 +253,17 @@ The default `context` is `document`. Choose another element or DocumentOrShadowR
 #### Parameters:
 
 Name | Type | Description |
------- | ------ | ------ |
-`selector` | string | CSS selector |
-`context?` | Node | context to query in, or `document` by default  |
+:------ | :------ | :------ |
+`selector` | *string* | CSS selector   |
+`context?` | Node | context to query in, or `document` by default    |
 
-**Returns:** Element \| null
+**Returns:** Element \| *null*
 
 ___
 
 ### querySelectorAll
 
-▸ **querySelectorAll**(`selector`: string, `context?`: Node): Element[]
-
-
+▸ **querySelectorAll**(`selector`: *string*, `context?`: Node): Element[]
 
 Query for all elements matching a CSS selector. Analogous to
 [`Document.querySelectorAll`](https://developer.mozilla.org/en-US/docs/Web/API/Document/querySelectorAll)
@@ -291,9 +273,9 @@ The default `context` is `document`. Choose another node to query within that co
 #### Parameters:
 
 Name | Type | Description |
------- | ------ | ------ |
-`selector` | string | CSS selector |
-`context?` | Node | context to query in, or `document` by default  |
+:------ | :------ | :------ |
+`selector` | *string* | CSS selector   |
+`context?` | Node | context to query in, or `document` by default    |
 
 **Returns:** Element[]
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -2502,9 +2502,9 @@
       }
     },
     "handlebars": {
-      "version": "4.7.6",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.6.tgz",
-      "integrity": "sha512-1f2BACcBfiwAfStCKZNrUCgqNZkGsAT7UM3kkYtXuLo0KnaVfjKOyf7PRzB6++aK9STyT1Pd2ZCPe3EGOXleXA==",
+      "version": "4.7.7",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.7.tgz",
+      "integrity": "sha512-aAcXm5OAfE/8IXkcZvCepKU3VzW1/39Fb5ZuqMtgI/hT8X2YgoMvBY5dLhq/cpOvw7Lk1nK/UF71aLG/ZnVYRA==",
       "dev": true,
       "requires": {
         "minimist": "^1.2.5",
@@ -2577,12 +2577,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
       "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
-      "dev": true
-    },
-    "highlight.js": {
-      "version": "10.4.1",
-      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.4.1.tgz",
-      "integrity": "sha512-yR5lWvNz7c85OhVAEAeFhVCc/GV4C30Fjzc/rCP0aCWzc1UUOPUk55dK/qdwTZHBvMZo+eZ2jpk62ndX/xMFlg==",
       "dev": true
     },
     "hosted-git-info": {
@@ -3891,6 +3885,15 @@
         "js-tokens": "^3.0.0 || ^4.0.0"
       }
     },
+    "lru-cache": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "dev": true,
+      "requires": {
+        "yallist": "^3.0.2"
+      }
+    },
     "lunr": {
       "version": "2.3.9",
       "resolved": "https://registry.npmjs.org/lunr/-/lunr-2.3.9.tgz",
@@ -3924,9 +3927,9 @@
       }
     },
     "marked": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-1.2.0.tgz",
-      "integrity": "sha512-tiRxakgbNPBr301ihe/785NntvYyhxlqcL3YaC8CaxJQh7kiaEtrN9B/eK2I2943Yjkh5gw25chYFDQhOMCwMA==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-2.0.0.tgz",
+      "integrity": "sha512-NqRSh2+LlN2NInpqTQnS614Y/3NkVMFFU6sJlRFEpxJ/LHuK/qJECH7/fXZjk4VZstPW/Pevjil/VtSONsLc7Q==",
       "dev": true
     },
     "media-typer": {
@@ -4512,6 +4515,15 @@
       "dev": true,
       "requires": {
         "mimic-fn": "^2.1.0"
+      }
+    },
+    "onigasm": {
+      "version": "2.2.5",
+      "resolved": "https://registry.npmjs.org/onigasm/-/onigasm-2.2.5.tgz",
+      "integrity": "sha512-F+th54mPc0l1lp1ZcFMyL/jTs2Tlq4SqIHKIXGZOR/VkHkF9A7Fr5rRr5+ZG/lWeRsyrClLYRq7s/yFQ/XhWCA==",
+      "dev": true,
+      "requires": {
+        "lru-cache": "^5.1.1"
       }
     },
     "opencollective-postinstall": {
@@ -5409,6 +5421,16 @@
         "rechoir": "^0.6.2"
       }
     },
+    "shiki": {
+      "version": "0.9.2",
+      "resolved": "https://registry.npmjs.org/shiki/-/shiki-0.9.2.tgz",
+      "integrity": "sha512-BjUCxVbxMnvjs8jC4b+BQ808vwjJ9Q8NtLqPwXShZ307HdXiDFYP968ORSVfaTNNSWYDBYdMnVKJ0fYNsoZUBA==",
+      "dev": true,
+      "requires": {
+        "onigasm": "^2.2.5",
+        "vscode-textmate": "^5.2.0"
+      }
+    },
     "signal-exit": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.3.tgz",
@@ -6141,70 +6163,83 @@
       }
     },
     "typedoc": {
-      "version": "0.19.2",
-      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.19.2.tgz",
-      "integrity": "sha512-oDEg1BLEzi1qvgdQXc658EYgJ5qJLVSeZ0hQ57Eq4JXy6Vj2VX4RVo18qYxRWz75ifAaYuYNBUCnbhjd37TfOg==",
+      "version": "0.20.28",
+      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.20.28.tgz",
+      "integrity": "sha512-8j0T8u9FuyDkoe+M/3cyoaGJSVgXCY9KwVoo7TLUnmQuzXwqH+wkScY530ZEdK6G39UZ2LFTYPIrL5eykWjx6A==",
       "dev": true,
       "requires": {
-        "fs-extra": "^9.0.1",
-        "handlebars": "^4.7.6",
-        "highlight.js": "^10.2.0",
-        "lodash": "^4.17.20",
+        "colors": "^1.4.0",
+        "fs-extra": "^9.1.0",
+        "handlebars": "^4.7.7",
+        "lodash": "^4.17.21",
         "lunr": "^2.3.9",
-        "marked": "^1.1.1",
+        "marked": "^2.0.0",
         "minimatch": "^3.0.0",
         "progress": "^2.0.3",
-        "semver": "^7.3.2",
         "shelljs": "^0.8.4",
-        "typedoc-default-themes": "^0.11.4"
+        "shiki": "^0.9.2",
+        "typedoc-default-themes": "^0.12.7"
       },
       "dependencies": {
         "fs-extra": {
-          "version": "9.0.1",
-          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.0.1.tgz",
-          "integrity": "sha512-h2iAoN838FqAFJY2/qVpzFXy+EBxfVE220PalAqQLDVsFOHLJrZvut5puAbCdNv6WJk+B8ihI+k0c7JK5erwqQ==",
+          "version": "9.1.0",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
+          "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
           "dev": true,
           "requires": {
             "at-least-node": "^1.0.0",
             "graceful-fs": "^4.2.0",
             "jsonfile": "^6.0.1",
-            "universalify": "^1.0.0"
+            "universalify": "^2.0.0"
+          }
+        },
+        "handlebars": {
+          "version": "4.7.7",
+          "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.7.tgz",
+          "integrity": "sha512-aAcXm5OAfE/8IXkcZvCepKU3VzW1/39Fb5ZuqMtgI/hT8X2YgoMvBY5dLhq/cpOvw7Lk1nK/UF71aLG/ZnVYRA==",
+          "dev": true,
+          "requires": {
+            "minimist": "^1.2.5",
+            "neo-async": "^2.6.0",
+            "source-map": "^0.6.1",
+            "uglify-js": "^3.1.4",
+            "wordwrap": "^1.0.0"
           }
         },
         "jsonfile": {
-          "version": "6.0.1",
-          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.0.1.tgz",
-          "integrity": "sha512-jR2b5v7d2vIOust+w3wtFKZIfpC2pnRmFAhAC/BuweZFQR8qZzxH1OyrQ10HmdVYiXWkYUqPVsz91cG7EL2FBg==",
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+          "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
           "dev": true,
           "requires": {
             "graceful-fs": "^4.1.6",
-            "universalify": "^1.0.0"
+            "universalify": "^2.0.0"
           }
         },
-        "semver": {
-          "version": "7.3.2",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
-          "integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==",
+        "lodash": {
+          "version": "4.17.21",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+          "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
           "dev": true
         },
         "universalify": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/universalify/-/universalify-1.0.0.tgz",
-          "integrity": "sha512-rb6X1W158d7pRQBg5gkR8uPaSfiids68LTJQYOtEUhoJUWBdaQHsuT/EUduxXYxcrt4r5PJ4fuHW1MHT6p0qug==",
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
+          "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
           "dev": true
         }
       }
     },
     "typedoc-default-themes": {
-      "version": "0.11.4",
-      "resolved": "https://registry.npmjs.org/typedoc-default-themes/-/typedoc-default-themes-0.11.4.tgz",
-      "integrity": "sha512-Y4Lf+qIb9NTydrexlazAM46SSLrmrQRqWiD52593g53SsmUFioAsMWt8m834J6qsp+7wHRjxCXSZeiiW5cMUdw==",
+      "version": "0.12.7",
+      "resolved": "https://registry.npmjs.org/typedoc-default-themes/-/typedoc-default-themes-0.12.7.tgz",
+      "integrity": "sha512-0XAuGEqID+gon1+fhi4LycOEFM+5Mvm2PjwaiVZNAzU7pn3G2DEpsoXnFOPlLDnHY6ZW0BY0nO7ur9fHOFkBLQ==",
       "dev": true
     },
     "typedoc-plugin-markdown": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/typedoc-plugin-markdown/-/typedoc-plugin-markdown-3.0.3.tgz",
-      "integrity": "sha512-cVa9BUkJw5IeadihNDlTy4e5yq1T0ZpNXzc+/vkgxdVJwgt1BQVQHSZYUNDa2R8nrlYmP9yt3ZQDxG9nIg4++A==",
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/typedoc-plugin-markdown/-/typedoc-plugin-markdown-3.5.0.tgz",
+      "integrity": "sha512-UzSTK5RpQVbIrcxV1ypHt3Pqr4O3DObYZIhcAXBazitHnpdl500cggXFHmxH7F/j3P3P2IBvPKpfnU6lzRdk8w==",
       "dev": true,
       "requires": {
         "handlebars": "^4.7.6"
@@ -6336,6 +6371,12 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/void-elements/-/void-elements-2.0.1.tgz",
       "integrity": "sha1-wGavtYK7HLQSjWDqkjkulNXp2+w=",
+      "dev": true
+    },
+    "vscode-textmate": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/vscode-textmate/-/vscode-textmate-5.2.0.tgz",
+      "integrity": "sha512-Uw5ooOQxRASHgu6C7GVvUxisKXfSgW4oFlO+aa+PAkgmH89O3CXxEEzNRNtHSqtXFTl0nAC1uYj0GMSH27uwtQ==",
       "dev": true
     },
     "which": {
@@ -6501,6 +6542,12 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
       "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
+      "dev": true
+    },
+    "yallist": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true
     },
     "yaml": {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "test:debug": "karma start --browsers=Chrome --single-run=false",
     "test:bundlesize": "bundlesize",
     "build": "rollup -c",
-    "typedoc": "rimraf typedoc && typedoc --includeDeclarations --excludeExternals --plugin typedoc-plugin-markdown --out typedoc ./types && node ./scripts/copy-typedoc-to-readme.js && rimraf typedoc",
+    "typedoc": "rimraf typedoc && typedoc --plugin typedoc-plugin-markdown --out typedoc ./types && node ./scripts/copy-typedoc-to-readme.js && rimraf typedoc",
     "prepare": "npm run build",
     "lint": "standard *.js {scripts,src,test}/**/*.js",
     "lint:fix": "standard --fix *.js  {scripts,src,test}/**/*.js"
@@ -57,8 +57,8 @@
     "standard": "^14.3.4",
     "string.prototype.endswith": "^0.2.0",
     "string.prototype.startswith": "^0.2.0",
-    "typedoc": "^0.19.2",
-    "typedoc-plugin-markdown": "^3.0.3",
+    "typedoc": "^0.20.28",
+    "typedoc-plugin-markdown": "^3.5.0",
     "typescript": "^4.0.3"
   },
   "files": [

--- a/scripts/copy-typedoc-to-readme.js
+++ b/scripts/copy-typedoc-to-readme.js
@@ -8,10 +8,10 @@ const END_MARKER = '<!-- end API -->'
 
 // Take the typedoc output and insert it directly into the README
 async function main () {
-  let api = await readFile('./typedoc/modules/_kagekiri_d_.md', 'utf8')
+  let api = await readFile('./typedoc/modules.md', 'utf8')
   api = api.substring(api.indexOf('\n## Functions'))
   api = api.replace('## Functions', '## API')
-  api = api.replace(/\*Defined in .*?\*/g, '')
+  api = api.replace(/\nDefined in: .*?\n/g, '')
 
   let readme = await readFile('./README.md', 'utf8')
   const startIdx = readme.indexOf(START_MARKER)

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "includeDeclarations": true,
+  "excludeExternals": true
+}


### PR DESCRIPTION
Updates `marked` to fix `npm audit`. Also that means we need to update `typedoc` and `typedoc-plugin-markdown`. Some minor breaking changes in here, but the TypeScript markdown docs are basically the same before and after.