### PR TITLE
chore: downgrade karma-rollup-preprocessor to 7.0.7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "karma-coverage": "^2.2.1",
         "karma-firefox-launcher": "^1.3.0",
         "karma-mocha": "^2.0.1",
-        "karma-rollup-preprocessor": "^7.0.8",
+        "karma-rollup-preprocessor": "7.0.7",
         "lint-staged": "^13.3.0",
         "mocha": "^10.4.0",
         "object-assign": "^4.1.1",
@@ -4651,9 +4651,9 @@
       }
     },
     "node_modules/karma-rollup-preprocessor": {
-      "version": "7.0.8",
-      "resolved": "https://registry.npmjs.org/karma-rollup-preprocessor/-/karma-rollup-preprocessor-7.0.8.tgz",
-      "integrity": "sha512-WiuBCS9qsatJuR17dghiTARBZ7LF+ml+eb7qJXhw7IbsdY0lTWELDRQC/93J9i6636CsAXVBL3VJF4WtaFLZzA==",
+      "version": "7.0.7",
+      "resolved": "https://registry.npmjs.org/karma-rollup-preprocessor/-/karma-rollup-preprocessor-7.0.7.tgz",
+      "integrity": "sha512-Y1QwsTCiCBp8sSALZdqmqry/mWIWIy0V6zonUIpy+0/D/Kpb2XZvR+JZrWfacQvcvKQdZFJvg6EwlnKtjepu3Q==",
       "dev": true,
       "dependencies": {
         "chokidar": "^3.3.1",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,9 @@
   },
   "license": "BSD-3-Clause",
   "dependencies": {},
+  "//": [
+    "karma-rollup-preprocessor is pinned due to a bug in 7.0.8: https://github.com/jlmakes/karma-rollup-preprocessor/issues/75"
+  ],
   "devDependencies": {
     "@rollup/plugin-buble": "^0.21.3",
     "@rollup/plugin-commonjs": "^15.1.0",
@@ -43,7 +46,7 @@
     "karma-coverage": "^2.2.1",
     "karma-firefox-launcher": "^1.3.0",
     "karma-mocha": "^2.0.1",
-    "karma-rollup-preprocessor": "^7.0.8",
+    "karma-rollup-preprocessor": "7.0.7",
     "lint-staged": "^13.3.0",
     "mocha": "^10.4.0",
     "object-assign": "^4.1.1",


### PR DESCRIPTION
I forgot about this particular bug: https://github.com/jlmakes/karma-rollup-preprocessor/issues/75

Downgrading this dep to 7.0.7 fixes the issue when running `npm run test:debug`.
