### PR TITLE
fix: check if getRootNode is a function before calling it.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -79,7 +79,7 @@ function getParent (element) {
     return element.parentElement
   }
   // if an element is inside the shadow DOM, break outside of it
-  const rootNode = element.getRootNode()
+  const rootNode = typeof element.getRootNode === 'function' ? element.getRootNode() : document
   /* istanbul ignore else */
   if (rootNode !== document) {
     return rootNode.host


### PR DESCRIPTION
When using this lib in Chrome 53 (Crosswalk),`getRootNode()` cannot be invoked (`TypeError: e.getRootNode is not a function`).

